### PR TITLE
Fix unpacking configs into slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fix (*Config).CountField returning 1 for arrays of any size. #43
+- Fix unpacking into slice/array top-level or if `inline`-tag is used. #45
 
 ## [0.3.0]
 

--- a/reify_test.go
+++ b/reify_test.go
@@ -345,6 +345,23 @@ func TestUnpackArray(t *testing.T) {
 	}
 }
 
+func TestUnpackArrayDirect(t *testing.T) {
+	c, _ := NewFrom(node{"a": []int{1, 2, 3}})
+	a, _ := c.Child("a", -1)
+
+	var table []int
+	err := a.Unpack(&table)
+	assert.NoError(t, err)
+	assert.Equal(t, []int{1, 2, 3}, table)
+
+	tmp := struct {
+		Table []int `config:",inline"`
+	}{}
+	err = a.Unpack(&tmp)
+	assert.NoError(t, err)
+	assert.Equal(t, []int{1, 2, 3}, tmp.Table)
+}
+
 func TestUnpackInline(t *testing.T) {
 	type SubType struct{ B bool }
 	type SubInterface struct{ B interface{} }


### PR DESCRIPTION
Fix unpacking into top-level slice/array or unpacking into slice if
`inline`-tag is used.