### PR TITLE
FAILED test case to expand an env variable with default value that contains 2 colons

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Card](https://goreportcard.com/badge/github.com/elastic/go-ucfg)](https://gorepo
 
 ## API Documentation
 
-The full API Documentat can be found [here](https://godoc.org/github.com/elastic/go-ucfg).
+The full API Documentation can be found [here](https://godoc.org/github.com/elastic/go-ucfg).
 
 ## Examples
 

--- a/variables_test.go
+++ b/variables_test.go
@@ -48,6 +48,8 @@ func TestVarExpParserSuccess(t *testing.T) {
 				cat(str("the "), ref("default"), str(" value")))},
 		{"exp with default containing }", "${test:abc$}def}",
 			exp(opDefault, str("test"), str("abc}def"))},
+		{"exp with default containing :", "${test:http://default:1234}",
+			exp(opDefault, str("test"), str("http://default:1234"))},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
After upgrading to the latest version of libbeat, I discovered an infinite loop when loading my custom beat which has the following cfg file:

server:
  url: ${SERVER_URL:http://127.0.0.1:12345}

Further investigations reveal that the application is waiting forever on this instruction:
go-ucfg/variables.go:351      lex <- sepDefToken

