### PR TITLE
VarExp parser fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Turn '$' into universal escape character, so '}' in default values can be escaped with '$'. #52
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+- Fix parsing ':' in expansion default value. #51, #52
 
 ## [0.3.1]
 

--- a/variables_test.go
+++ b/variables_test.go
@@ -22,6 +22,9 @@ func TestVarExpParserSuccess(t *testing.T) {
 		expected   varEvaler
 	}{
 		{"plain string", "string", str("string")},
+		{"string containing :", "just:a:string", str("just:a:string")},
+		{"string containing }", "abc } def", str("abc } def")},
+		{"string with escaped var", "escaped $${var}", str("escaped ${var}")},
 		{"reference", "${reference}", ref("reference")},
 		{"exp in middle", "test ${splice} this",
 			cat(str("test "), ref("splice"), str(" this"))},
@@ -43,6 +46,8 @@ func TestVarExpParserSuccess(t *testing.T) {
 			exp(opDefault,
 				str("test"),
 				cat(str("the "), ref("default"), str(" value")))},
+		{"exp with default containing }", "${test:abc$}def}",
+			exp(opDefault, str("test"), str("abc}def"))},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
- do not block if parser errors, but lexer still active
- fix parsing ':' in expansion default value
- turn '$' into universal escape character, so '}' in default
  values can be escaped with '$'
- add some more unit tests