### PR TITLE
Add godoc comments to ucfg core

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,10 @@
+// Package ucfg provides a common representation for hierarchical configurations.
+//
+// The common representation provided by the Config type can be used with different
+// configuration file formats like XML, JSON, HSJSON, YAML, or TOML.
+//
+// Config provides a low level and a high level interface for reading settings
+// with additional features like custom unpackers, validation and capturing
+// sub-configurations for deferred interpretation, lazy intra-configuration
+// variable expansion, and OS environment variable expansion.
+package ucfg

--- a/error.go
+++ b/error.go
@@ -7,13 +7,18 @@ import (
 	"runtime/debug"
 )
 
+// Error type returned by all public functions in go-ucfg.
 type Error interface {
 	error
-	Reason() error
 
 	// error class, one of ErrConfig, ErrImplementation, ErrUnknown
 	Class() error
 
+	// The internal reason error code like ErrMissing, ErrRequired,
+	// ErrTypeMismatch and others.
+	Reason() error
+
+	// The error message.
 	Message() string
 
 	// [optional] path of config element error occurred for
@@ -27,6 +32,7 @@ type baseError struct {
 	reason  error
 	class   error
 	message string
+	path    string
 }
 
 type criticalError struct {
@@ -34,13 +40,7 @@ type criticalError struct {
 	trace string
 }
 
-type pathError struct {
-	baseError
-	meta *Meta
-	path string
-}
-
-// error Reasons
+// Error Reasons
 var (
 	ErrMissing = errors.New("missing field")
 
@@ -79,28 +79,30 @@ var (
 	ErrEmpty = errors.New("empty field")
 )
 
-// error classes
+// Error Classes
 var (
 	ErrConfig         = errors.New("Configuration error")
 	ErrImplementation = errors.New("Implementation error")
 	ErrUnknown        = errors.New("Unspecified")
 )
 
-func (e baseError) Message() string { return e.Error() }
-func (e baseError) Reason() error   { return e.reason }
-func (e baseError) Class() error    { return e.class }
-func (e baseError) Trace() string   { return "" }
-func (e baseError) Path() string    { return "" }
+func (e baseError) Error() string { return e.Message() }
+func (e baseError) Reason() error { return e.reason }
+func (e baseError) Class() error  { return e.class }
+func (e baseError) Trace() string { return "" }
+func (e baseError) Path() string  { return e.path }
 
-func (e baseError) Error() string {
+func (e baseError) Message() string {
 	if e.message == "" {
 		return e.reason.Error()
 	}
 	return e.message
 }
 
+func (e criticalError) Trace() string { return e.trace }
+
 func (e criticalError) Error() string {
-	return fmt.Sprintf("%s\nTrace:%v\n", e.baseError, e.trace)
+	return fmt.Sprintf("%s\nTrace:%v\n", e.baseError.Message(), e.trace)
 }
 
 func raiseErr(reason error, message string) Error {
@@ -126,21 +128,14 @@ func raiseCritical(reason error, message string) Error {
 		message = fmt.Sprintf("(assert) %v", message)
 	}
 	return criticalError{
-		baseError{reason, ErrImplementation, message},
+		baseError{reason, ErrImplementation, message, ""},
 		string(debug.Stack()),
 	}
 }
 
 func raisePathErr(reason error, meta *Meta, message, path string) Error {
-	// fmt.Printf("path err, reason='%v', meta=%v, message='%v', path='%v'\n", reason, meta, message, path)
 	message = messagePath(reason, meta, message, path)
-	// fmt.Printf("  -> report message: %v\n", message)
-
-	return pathError{
-		baseError{reason, ErrConfig, message},
-		meta,
-		path,
-	}
+	return baseError{reason, ErrConfig, message, path}
 }
 
 func messageMeta(message string, meta *Meta) string {

--- a/getset.go
+++ b/getset.go
@@ -1,7 +1,7 @@
 package ucfg
 
 // ******************************************************************************
-// Low level getters and setters (do we actually need this?)
+// Low level getters and setters
 // ******************************************************************************
 
 func convertErr(opts *options, v value, err error, to string) Error {
@@ -11,8 +11,12 @@ func convertErr(opts *options, v value, err error, to string) Error {
 	return raiseConversion(opts, v, err, to)
 }
 
-// number of elements for this field. If config value is a list, returns number
-// of elements in list
+// CountField returns number of entries in a table or 1 if entry is a primitive value.
+// Primitives settings can be handled like a list with 1 entry.
+//
+// If name is empty, the total number of top-level settings is returned.
+//
+// CountField supports the options: PathSep, Env, Resolve, ResolveEnv
 func (c *Config) CountField(name string, opts ...Option) (int, error) {
 	if name == "" {
 		return len(c.fields.array()) + len(c.fields.dict()), nil
@@ -24,6 +28,16 @@ func (c *Config) CountField(name string, opts ...Option) (int, error) {
 	return -1, raiseMissing(c, name)
 }
 
+// Bool reads a boolean setting returning an error if the setting has no
+// boolean value.
+//
+// The setting path is constructed from name and idx. If name is set and idx is -1,
+// only the name is used to access the setting by name. If name is empty, idx
+// must be >= 0, assuming the Config is a list. If both name and idx are set,
+// the name must point to a list. The number of entries in a named list can be read
+// using CountField.
+//
+// Bool supports the options: PathSep, Env, Resolve, ResolveEnv
 func (c *Config) Bool(name string, idx int, opts ...Option) (bool, error) {
 	O := makeOptions(opts)
 	v, err := c.getField(name, idx, O)
@@ -34,6 +48,16 @@ func (c *Config) Bool(name string, idx int, opts ...Option) (bool, error) {
 	return b, convertErr(O, v, fail, "bool")
 }
 
+// Strings reads a string setting returning an error if the setting has
+// no string or primitive value convertible to string.
+//
+// The setting path is constructed from name and idx. If name is set and idx is -1,
+// only the name is used to access the setting by name. If name is empty, idx
+// must be >= 0, assuming the Config is a list. If both name and idx are set,
+// the name must point to a list. The number of entries in a named list can be read
+// using CountField.
+//
+// String supports the options: PathSep, Env, Resolve, ResolveEnv
 func (c *Config) String(name string, idx int, opts ...Option) (string, error) {
 	O := makeOptions(opts)
 	v, err := c.getField(name, idx, O)
@@ -44,6 +68,17 @@ func (c *Config) String(name string, idx int, opts ...Option) (string, error) {
 	return s, convertErr(O, v, fail, "string")
 }
 
+// Int reads an int64 value returning an error if the setting is
+// not integer value, the primitive value is not convertible to int or a conversion
+// would create an integer overflow.
+//
+// The setting path is constructed from name and idx. If name is set and idx is -1,
+// only the name is used to access the setting by name. If name is empty, idx
+// must be >= 0, assuming the Config is a list. If both name and idx are set,
+// the name must point to a list. The number of entries in a named list can be read
+// using CountField.
+//
+// Int supports the options: PathSep, Env, Resolve, ResolveEnv
 func (c *Config) Int(name string, idx int, opts ...Option) (int64, error) {
 	O := makeOptions(opts)
 	v, err := c.getField(name, idx, O)
@@ -54,6 +89,17 @@ func (c *Config) Int(name string, idx int, opts ...Option) (int64, error) {
 	return i, convertErr(O, v, fail, "int")
 }
 
+// Uint reads an uint64 value returning an error if the setting is
+// not unsigned value, the primitive value is not convertible to uint64 or a conversion
+// would create an integer overflow.
+//
+// The setting path is constructed from name and idx. If name is set and idx is -1,
+// only the name is used to access the setting by name. If name is empty, idx
+// must be >= 0, assuming the Config is a list. If both name and idx are set,
+// the name must point to a list. The number of entries in a named list can be read
+// using CountField.
+//
+// Uint supports the options: PathSep, Env, Resolve, ResolveEnv
 func (c *Config) Uint(name string, idx int, opts ...Option) (uint64, error) {
 	O := makeOptions(opts)
 	v, err := c.getField(name, idx, O)
@@ -64,6 +110,16 @@ func (c *Config) Uint(name string, idx int, opts ...Option) (uint64, error) {
 	return u, convertErr(O, v, fail, "uint")
 }
 
+// Float reads a float64 value returning an error if the setting is
+// not a float value or the primitive value is not convertible to float.
+//
+// The setting path is constructed from name and idx. If name is set and idx is -1,
+// only the name is used to access the setting by name. If name is empty, idx
+// must be >= 0, assuming the Config is a list. If both name and idx are set,
+// the name must point to a list. The number of entries in a named list can be read
+// using CountField.
+//
+// Float supports the options: PathSep, Env, Resolve, ResolveEnv
 func (c *Config) Float(name string, idx int, opts ...Option) (float64, error) {
 	O := makeOptions(opts)
 	v, err := c.getField(name, idx, O)
@@ -74,6 +130,16 @@ func (c *Config) Float(name string, idx int, opts ...Option) (float64, error) {
 	return f, convertErr(O, v, fail, "float")
 }
 
+// Child returns a child configuration or an error if the setting requested is a
+// primitive value only.
+//
+// The setting path is constructed from name and idx. If name is set and idx is -1,
+// only the name is used to access the setting by name. If name is empty, idx
+// must be >= 0, assuming the Config is a list. If both name and idx are set,
+// the name must point to a list. The number of entries in a named list can be read
+// using CountField.
+//
+// Child supports the options: PathSep, Env, Resolve, ResolveEnv
 func (c *Config) Child(name string, idx int, opts ...Option) (*Config, error) {
 	O := makeOptions(opts)
 	v, err := c.getField(name, idx, O)
@@ -84,30 +150,89 @@ func (c *Config) Child(name string, idx int, opts ...Option) (*Config, error) {
 	return c, convertErr(O, v, fail, "object")
 }
 
+// SetBool sets a boolean primitive value. An error is returned if the new name
+// is invalid.
+//
+// The setting path is constructed from name and idx. If name is set and idx is -1,
+// only the name is used to access the setting by name. If name is empty, idx
+// must be >= 0, assuming the Config is a list. If both name and idx are set,
+// the name must point to a list. The number of entries in a named list can be read
+// using CountField.
+//
+// SetBool supports the options: PathSep, MetaData
 func (c *Config) SetBool(name string, idx int, value bool, opts ...Option) error {
 	return c.setField(name, idx, &cfgBool{b: value}, opts)
 }
 
+// SetInt sets an integer primitive value. An error is returned if the new
+// name is invalid.
+//
+// The setting path is constructed from name and idx. If name is set and idx is -1,
+// only the name is used to access the setting by name. If name is empty, idx
+// must be >= 0, assuming the Config is a list. If both name and idx are set,
+// the name must point to a list. The number of entries in a named list can be read
+// using CountField.
+//
+// SetInt supports the options: PathSep, MetaData
 func (c *Config) SetInt(name string, idx int, value int64, opts ...Option) error {
 	return c.setField(name, idx, &cfgInt{i: value}, opts)
 }
 
+// SetUint sets an unsigned integer primitive value. An error is returned if
+// the name is invalid.
+//
+// The setting path is constructed from name and idx. If name is set and idx is -1,
+// only the name is used to access the setting by name. If name is empty, idx
+// must be >= 0, assuming the Config is a list. If both name and idx are set,
+// the name must point to a list. The number of entries in a named list can be read
+// using CountField.
+//
+// SetUint supports the options: PathSep, MetaData
 func (c *Config) SetUint(name string, idx int, value uint64, opts ...Option) error {
 	return c.setField(name, idx, &cfgUint{u: value}, opts)
 }
 
+// SetFloat sets an floating point primitive value. An error is returned if
+// the name is invalid.
+//
+// The setting path is constructed from name and idx. If name is set and idx is -1,
+// only the name is used to access the setting by name. If name is empty, idx
+// must be >= 0, assuming the Config is a list. If both name and idx are set,
+// the name must point to a list. The number of entries in a named list can be read
+// using CountField.
+//
+// SetFloat supports the options: PathSep, MetaData
 func (c *Config) SetFloat(name string, idx int, value float64, opts ...Option) error {
 	return c.setField(name, idx, &cfgFloat{f: value}, opts)
 }
 
+// SetString sets string value. An error is returned if the name is invalid.
+//
+// The setting path is constructed from name and idx. If name is set and idx is -1,
+// only the name is used to access the setting by name. If name is empty, idx
+// must be >= 0, assuming the Config is a list. If both name and idx are set,
+// the name must point to a list. The number of entries in a named list can be read
+// using CountField.
+//
+// SetString supports the options: PathSep, MetaData
 func (c *Config) SetString(name string, idx int, value string, opts ...Option) error {
 	return c.setField(name, idx, &cfgString{s: value}, opts)
 }
 
+// SetChild adds a sub-configuration. An error is returned if the name is invalid.
+//
+// The setting path is constructed from name and idx. If name is set and idx is -1,
+// only the name is used to access the setting by name. If name is empty, idx
+// must be >= 0, assuming the Config is a list. If both name and idx are set,
+// the name must point to a list. The number of entries in a named list can be read
+// using CountField.
+//
+// SetChild supports the options: PathSep, MetaData
 func (c *Config) SetChild(name string, idx int, value *Config, opts ...Option) error {
 	return c.setField(name, idx, cfgSub{c: value}, opts)
 }
 
+// getField supports the options: PathSep, Env, Resolve, ResolveEnv
 func (c *Config) getField(name string, idx int, opts *options) (value, Error) {
 	p := parsePathIdx(name, opts.pathSep, idx)
 	v, err := p.GetValue(c, opts)
@@ -121,6 +246,7 @@ func (c *Config) getField(name string, idx int, opts *options) (value, Error) {
 	return v, nil
 }
 
+// setField supports the options: PathSep, MetaData
 func (c *Config) setField(name string, idx int, v value, options []Option) Error {
 	opts := makeOptions(options)
 	p := parsePathIdx(name, opts.pathSep, idx)

--- a/merge.go
+++ b/merge.go
@@ -7,6 +7,46 @@ import (
 	"time"
 )
 
+// Merge a map, a slice, a struct or another Config object into c.
+//
+// Merge traverses the value from recursively copying all values into a hierarchy
+// of Config objects plus primitives into c.
+//
+// Merge supports the options: PathSep, MetaData, StructTag, VarExp
+//
+// Merge uses the type-dependent default encodings:
+//  - Boolean values are encoded as booleans.
+//  - Integer are encoded as int64 values, unsigned integer values as uint64 and
+//    floats as float64 values.
+//  - Strings are copied into string values.
+//    If the VarExp is set, string fields will be parsed into
+//    variable expansion expressions. The expression can reference any
+//    other setting by absolute name.
+//  - Array and slices are copied into new Config objects with index accessors only.
+//  - Struct values and maps with key type string are encoded as Config objects with
+//    named field accessors.
+//  - Config objects will be copied and added to the current hierarchy.
+//
+// The `config` struct tag (configurable via StructTag option) can be used to
+// set the field name and enable additional merging settings per field:
+//
+//  // field appears in Config as key "myName"
+//  Field int `config:"myName"`
+//
+//  // field appears in sub-Config "mySub" as key "myName" (requires PathSep("."))
+//  Field int `config:"mySub.myName"`
+//
+//  // field is processed as if keys are part of outer struct (type can be a
+//  // struct, a slice, an array, a map or of type *Config)
+//  Field map[string]interface{} `config:",inline"`
+//
+//
+// Returns an error if merging fails to normalize and validate the from value.
+// If duplicate setting names are detected in the input, merging fails as well.
+//
+// Config cannot represent cyclic structures and Merge does not handle them
+// well. Passing cyclic structures to Merge will result in an infinite recursive
+// loop.
 func (c *Config) Merge(from interface{}, options ...Option) error {
 	opts := makeOptions(options)
 	other, err := normalize(opts, from)

--- a/opts.go
+++ b/opts.go
@@ -2,6 +2,8 @@ package ucfg
 
 import "os"
 
+// Option type implementing additional options to be passed
+// to go-ucfg library functions.
 type Option func(*options)
 
 type options struct {
@@ -14,53 +16,76 @@ type options struct {
 	varexp       bool
 }
 
+// StructTag option sets the struct tag name to use for looking up
+// field names and options in `Unpack` and `Merge`.
+// The default struct tag in `config`.
 func StructTag(tag string) Option {
 	return func(o *options) {
 		o.tag = tag
 	}
 }
 
+// ValidatorTag option sets the struct tag name used to set validators
+// on struct fields in `Unpack`.
+// The default struct tag in `validate`.
 func ValidatorTag(tag string) Option {
 	return func(o *options) {
 		o.validatorTag = tag
 	}
 }
 
+// PathSep sets the path separator used to split up names into a tree like hierarchy.
+// If PathSep is not set, field names will not be split.
 func PathSep(sep string) Option {
 	return func(o *options) {
 		o.pathSep = sep
 	}
 }
 
+// MetaData option passes additional metadata (currently only source of the
+// configuration) to be stored internally (e.g. for error reporting).
 func MetaData(meta Meta) Option {
 	return func(o *options) {
 		o.meta = &meta
 	}
 }
 
+// Env option adds another configuration for variable expansion to be used, if
+// the path to look up does not exist in the actual configuration. Env can be used
+// multiple times in order to add more lookup environments.
 func Env(e *Config) Option {
 	return func(o *options) {
 		o.env = append(o.env, e)
 	}
 }
 
+// Resolve option adds a callback used by variable name expansion. The callback
+// will be called if a variable can not be resolved from within the actual configuration
+// or any of its environments.
 func Resolve(fn func(name string) (string, error)) Option {
 	return func(o *options) {
 		o.resolvers = append(o.resolvers, fn)
 	}
 }
 
-var ResolveEnv = Resolve(func(name string) (string, error) {
-	value := os.Getenv(name)
-	if value == "" {
-		return "", ErrMissing
-	}
-	return value, nil
-})
+// ResolveEnv option adds a look up callback looking up values in the available
+// OS environment variables.
+var ResolveEnv Option = doResolveEnv
 
-var VarExp Option = func(o *options) {
-	o.varexp = true
+func doResolveEnv(o *options) {
+	o.resolvers = append(o.resolvers, func(name string) (string, error) {
+		value := os.Getenv(name)
+		if value == "" {
+			return "", ErrMissing
+		}
+		return value, nil
+	})
 }
+
+// VarExp option enables support for variable expansion. Resolve and Env options will only be effective if  VarExp is set.
+var VarExp Option = doVarExp
+
+func doVarExp(o *options) { o.varexp = true }
 
 func makeOptions(opts []Option) *options {
 	o := options{

--- a/reify.go
+++ b/reify.go
@@ -6,6 +6,96 @@ import (
 	"time"
 )
 
+// Unpack unpacks c into a struct, a map, or a slice allocating maps, slices,
+// and pointers as necessary.
+//
+// Unpack supports the options: PathSep, StructTag, ValidatorTag, Env, Resolve,
+// ResolveEnv.
+//
+// When unpacking into a value, Unpack first will try to call Unpack if the
+// value implements the Unpacker interface. Otherwise, Unpack tries to convert
+// the internal value into the target type:
+//
+//  # Primitive types
+//
+//  bool: requires setting of type bool or string which parses into a
+//     boolean value (true, false, on, off)
+//  int(8, 16, 32, 64): requires any number type convertible to int or a string
+//      parsing to int. Fails if the target value would overflow.
+//  uint(8, 16, 32, 64): requires any number type convertible to int or a string
+//       parsing to int. Fails if the target value is negative or would overflow.
+//  float(32, 64): requires any number type convertible to float or a string
+//       parsing to float. Fails if the target value is negative or would overflow.
+//  string: requires any primitive value which is serialized into a string.
+//
+//  # Special types:
+//
+//  time.Duration: requires a number setting converted to seconds or a string
+//       parsed into time.Duration via time.ParseDuration.
+//  *regexp.Regexp: requires a string being compiled into a regular expression
+//       using regexp.Compile.
+//  *Config: requires a Config object to be stored by pointer into the target
+//       value. Can be used to capture a sub-Config without interpreting
+//       the settings yet.
+//
+//   # Arrays/Slices:
+//
+//  Requires a Config object with indexed entries. Named entries will not be
+//  unpacked into the Array/Slice. Primitive values will be handled like arrays
+//  of length 1.
+//
+//  # Map
+//
+//  Requires a Config object with all named top-level entries being unpacked into
+//  the map.
+//
+//  # Struct
+//
+//  Requires a Config object. All named values in the Config object will be unpacked
+//  into the struct its fields, if the name is available in the struct.
+//  A field its name is set using the `config` struct tag (configured by StructTag)
+//  If tag is missing or no field name is configured in the tag, the field name
+//  itself will be used.
+//
+//
+// Fields available in a struct or a map, but not in the Config object, will not
+// be touched. Default values should be set in the target value before calling Unpack.
+//
+// Type aliases like "type myTypeAlias T" are unpacked using Unpack if the alias
+// implements the Unpacker interface. Otherwise unpacking rules for type T will be used.
+//
+// When unpacking a value, the Validate method will be called if the value
+// implements the Validator interface. Unpacking a struct field the validator
+// options will be applied to the unpacked value as well.
+//
+// Struct field validators are set using the `validate` tag (configurable by
+// ValidatorTag). Default validators options are:
+//
+//  required: check value is set and not empty
+//  nonzero: check numeric value != 0 or string/slice not being empty
+//  positive: check numeric value >= 0
+//  min=<value>: check numeric value >= <value>. If target type is time.Duration,
+//       <value> can be a duration.
+//  max=<value>: check numeric value <= <value>. If target type is time.Duration,
+//     <value> can be a duration.
+//
+// If a config value is not the convertible to the target type, or overflows the
+// target type, Unpack will abort immediately and return the appropriate error.
+//
+// If validator tags or validation provided by Validate or Unmarshal fails,
+// Unpack will abort immediately and return the validate error.
+//
+// When unpacking into an interface{} value, Unpack will store a value of one of
+// these types in the value:
+//
+//   bool for boolean values
+//   int64 for signed integer values
+//   uint64 for unsigned integer values
+//   float64 for floating point values
+//   string for string values
+//   []interface{} for list-only Config objects
+//   map[string]interface{} for Config objects
+//   nil for pointers if key has a nil value
 func (c *Config) Unpack(to interface{}, options ...Option) error {
 	opts := makeOptions(options)
 

--- a/ucfg.go
+++ b/ucfg.go
@@ -7,6 +7,15 @@ import (
 	"time"
 )
 
+// Config object to store hierarchical configurations into. Config can be
+// both a dictionary and a list holding primitive values. Primitive values
+// can be booleans, integers, float point numbers and strings.
+//
+// Config provides a low level interface for setting and getting settings
+// via SetBool, SetInt, SetUing, SetFloat, SetString, SetChild, Bool, Int, Uint,
+// Float, String, and Child.
+//
+// A more user-friendly high level interface is provided via Unpack and Merge.
 type Config struct {
 	ctx      context
 	metadata *Meta
@@ -24,12 +33,18 @@ type fields struct {
 	a []value
 }
 
-// Meta holds additional meta data per config value
+// Meta holds additional meta data per config value.
 type Meta struct {
 	Source string
 }
 
+// Unpacker type used by Unpack to allow types to implement custom configuration
+// unpacking.
 type Unpacker interface {
+	// Unpack is called if a setting of field has a type implementing Unpacker.
+	//
+	// The interface{} value passed to Unpack can be of type: bool, int64, uint64,
+	// float64, string, []interface{} or map[string]interface{}.
 	Unpack(interface{}) error
 }
 
@@ -53,12 +68,17 @@ var (
 	tRegexp   = reflect.TypeOf(regexp.Regexp{})
 )
 
+// New creates a new empty Config object.
 func New() *Config {
 	return &Config{
 		fields: &fields{nil, nil},
 	}
 }
 
+// NewFrom creates a new config object normalizing and copying from into the new
+// Config object. NewFrom uses Merge to copy from.
+//
+// NewFrom supports the options: PathSep, MetaData, StructTag, VarExp
 func NewFrom(from interface{}, opts ...Option) (*Config, error) {
 	c := New()
 	if err := c.Merge(from, opts...); err != nil {
@@ -67,14 +87,17 @@ func NewFrom(from interface{}, opts ...Option) (*Config, error) {
 	return c, nil
 }
 
+// IsDict checks if c has named keys.
 func (c *Config) IsDict() bool {
 	return c.fields.dict() != nil
 }
 
+// IsArray checks if c has index only accessible settings.
 func (c *Config) IsArray() bool {
 	return c.fields.array() != nil
 }
 
+// GetFields returns a list of all top-level named keys in c.
 func (c *Config) GetFields() []string {
 	var names []string
 	for k := range c.fields.dict() {
@@ -83,19 +106,26 @@ func (c *Config) GetFields() []string {
 	return names
 }
 
+// HasField checks if c has a top-level named key name.
 func (c *Config) HasField(name string) bool {
 	_, ok := c.fields.get(name)
 	return ok
 }
 
+// Path gets the absolute path of c separated by sep. If c is a root-Config an
+// empty string will be returned.
 func (c *Config) Path(sep string) string {
 	return c.ctx.path(sep)
 }
 
+// PathOf gets the absolute path of a potential setting field in c with name
+// separated by sep.
 func (c *Config) PathOf(field, sep string) string {
 	return c.ctx.pathOf(field, sep)
 }
 
+// Parent returns the parent configuration or nil if c is already a root
+// Configuration.
 func (c *Config) Parent() *Config {
 	ctx := c.ctx
 	for {

--- a/validator_test.go
+++ b/validator_test.go
@@ -14,7 +14,7 @@ type myNonzeroInt int
 type structValidator struct{ I int }
 type ptrStructValidator struct{ I int }
 
-var testErrZero = errors.New("value must not be 0")
+var errZeroTest = errors.New("value must not be 0")
 
 func (m myNonzeroInt) Validate() error {
 	return testZeroErr(int(m))
@@ -30,7 +30,7 @@ func (p *ptrStructValidator) Validate() error {
 
 func testZeroErr(i int) error {
 	if i == 0 {
-		return testErrZero
+		return errZeroTest
 	}
 	return nil
 }

--- a/variables.go
+++ b/variables.go
@@ -390,9 +390,7 @@ func lexer(in string) (<-chan token, <-chan error) {
 }
 
 func parseVarExp(lex <-chan token, pathSep string) (varEvaler, error) {
-	stack := []parseState{
-		parseState{st: stLeft},
-	}
+	stack := []parseState{{st: stLeft}}
 
 	// parser loop
 	for tok := range lex {


### PR DESCRIPTION
Add doc comments to all public symbols exported by go-ucfg core. 

For review run `godoc -http=:6060` and point browser to `http://localhost:6060/pkg/github.com/elastic/go-ucfg/`
