### PR TITLE
Enhance flag value parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Syntax for passing lists and dictionaries to flags. #72
 
 ### Changed
 

--- a/flag/parse.go
+++ b/flag/parse.go
@@ -1,0 +1,265 @@
+package flag
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+type flagParser struct {
+	input string
+}
+
+// parseValues parses command line arguments, supporting:
+// boolean, numbers, strings, arrays, objects.
+//
+// The parser implements a superset of JSON, but only a subset of YAML by
+// allowing for arrays and objects having a trailing comma. In addition 3
+// strings types are supported:
+//
+// 1. single quoted string (no unescaping of any characters)
+// 2. double quoted strings (characters are escaped)
+// 3. strings without quotes. String parsing stops in
+//   special characters like '[]{},:'
+func parseValue(value string) (interface{}, error) {
+	p := &flagParser{value}
+	v, err := p.parseValue()
+	if err != nil {
+		return nil, fmt.Errorf("%v when parsing '%v'", err.Error(), value)
+	}
+	return v, nil
+}
+
+func (p *flagParser) parseValue() (interface{}, error) {
+	p.ignoreWhitespace()
+	in := p.input
+	if in == "" {
+		return nil, nil
+	}
+
+	switch in[0] {
+	case '[':
+		return p.parseArray()
+	case '{':
+		return p.parseObj()
+	case '"':
+		return p.parseStringDQuote()
+	case '\'':
+		return p.parseStringSQuote()
+	default:
+		return p.parsePrimitive()
+	}
+}
+
+func (p *flagParser) ignoreWhitespace() {
+	p.input = strings.TrimLeftFunc(p.input, unicode.IsSpace)
+}
+
+func (p *flagParser) parseArray() (interface{}, error) {
+	p.input = p.input[1:]
+
+	var values []interface{}
+loop:
+	for {
+		p.ignoreWhitespace()
+		if p.input[0] == ']' {
+			p.input = p.input[1:]
+			break
+		}
+
+		v, err := p.parseValue()
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, v)
+
+		p.ignoreWhitespace()
+		if p.input == "" {
+			return nil, errors.New("array closing ']' missing")
+		}
+
+		next := p.input[0]
+		p.input = p.input[1:]
+
+		switch next {
+		case ']':
+			break loop
+		case ',':
+			continue
+		default:
+			return nil, errors.New("array expected ',' or ']'")
+		}
+
+	}
+
+	if len(values) == 0 {
+		return nil, nil
+	}
+
+	return values, nil
+}
+
+func (p *flagParser) parseObj() (interface{}, error) {
+	p.input = p.input[1:]
+
+	O := map[string]interface{}{}
+
+loop:
+	for {
+		p.ignoreWhitespace()
+		if p.input[0] == '}' {
+			p.input = p.input[1:]
+			break
+		}
+
+		k, err := p.parseKey()
+		if err != nil {
+			return nil, err
+		}
+
+		p.ignoreWhitespace()
+		if err := p.expectChar(':'); err != nil {
+			return nil, err
+		}
+
+		v, err := p.parseValue()
+		if err != nil {
+			return nil, err
+		}
+
+		if p.input == "" {
+			return nil, errors.New("dictionary expected ',' or '}'")
+		}
+
+		O[k] = v
+		next := p.input[0]
+		p.input = p.input[1:]
+
+		switch next {
+		case '}':
+			break loop
+		case ',':
+			continue
+		default:
+			return nil, errors.New("dictionary expected ',' or '}'")
+		}
+	}
+
+	// empty object
+	if len(O) == 0 {
+		return nil, nil
+	}
+
+	return O, nil
+}
+
+func (p *flagParser) parseKey() (string, error) {
+	in := p.input
+	if in == "" {
+		return "", errors.New("expected key")
+	}
+
+	switch in[0] {
+	case '"':
+		return p.parseStringDQuote()
+	case '\'':
+		return p.parseStringSQuote()
+	default:
+		return p.parseNonQuotedString()
+	}
+}
+
+func (p *flagParser) parseStringDQuote() (string, error) {
+	in := p.input
+	off := 1
+	var i int
+	for {
+		i = strings.IndexByte(in[off:], '"')
+		if i < 0 {
+			return "", errors.New("Missing \" to close string ")
+		}
+
+		i += off
+		if in[i-1] != '\\' {
+			break
+		}
+		off = i + 1
+	}
+
+	p.input = in[i+1:]
+	return strconv.Unquote(in[:i+1])
+}
+
+func (p *flagParser) parseStringSQuote() (string, error) {
+	in := p.input
+	i := strings.IndexByte(in[1:], '\'')
+	if i < 0 {
+		return "", errors.New("missing ' to close string")
+	}
+
+	p.input = in[i+2:]
+	return in[1 : 1+i], nil
+}
+
+func (p *flagParser) parseNonQuotedString() (string, error) {
+	in := p.input
+	idx := strings.IndexAny(in, ",:[]{}")
+
+	if idx == 0 {
+		return "", fmt.Errorf("unexpected '%v'", string(in[idx]))
+	}
+
+	content, in := in, ""
+	if idx > 0 {
+		content, in = content[:idx], content[idx:]
+	}
+	p.input = in
+
+	return strings.TrimSpace(content), nil
+}
+
+func (p *flagParser) parsePrimitive() (interface{}, error) {
+	content, err := p.parseNonQuotedString()
+	if err != nil {
+		return nil, err
+	}
+
+	if content == "null" {
+		return nil, nil
+	}
+	if b, ok := parseBoolValue(content); ok {
+		return b, nil
+	}
+	if n, err := strconv.ParseUint(content, 0, 64); err == nil {
+		return n, nil
+	}
+	if n, err := strconv.ParseInt(content, 0, 64); err == nil {
+		return n, nil
+	}
+	if n, err := strconv.ParseFloat(content, 64); err == nil {
+		return n, nil
+	}
+
+	return content, nil
+}
+
+func (p *flagParser) expectChar(c byte) error {
+	if p.input == "" || p.input[0] != c {
+		return fmt.Errorf("expected '%v'", string(c))
+	}
+
+	p.input = p.input[1:]
+	return nil
+}
+
+func parseBoolValue(str string) (value bool, ok bool) {
+	switch str {
+	case "t", "T", "true", "TRUE", "True", "on", "ON":
+		return true, true
+	case "f", "F", "false", "FALSE", "False", "off", "OFF":
+		return false, true
+	}
+	return false, false
+}

--- a/flag/parse_test.go
+++ b/flag/parse_test.go
@@ -40,6 +40,10 @@ func TestFlagValueParsing(t *testing.T) {
 		// test arrays
 		{`[]`, nil},
 		{
+			`a,b,c`,
+			[]interface{}{"a", "b", "c"},
+		},
+		{
 			`[array, 1, true, "abc"]`,
 			[]interface{}{"array", uint64(1), true, "abc"},
 		},
@@ -64,6 +68,19 @@ func TestFlagValueParsing(t *testing.T) {
 				"key 3": []interface{}{"test", "test2", false},
 				"nested key": map[string]interface{}{
 					"a": uint64(2),
+				},
+			},
+		},
+
+		// array of top-level dictionaries
+		{
+			`{key: 1},{key: 2}`,
+			[]interface{}{
+				map[string]interface{}{
+					"key": uint64(1),
+				},
+				map[string]interface{}{
+					"key": uint64(2),
 				},
 			},
 		},

--- a/flag/parse_test.go
+++ b/flag/parse_test.go
@@ -1,0 +1,117 @@
+package flag
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlagValueParsing(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		// null
+		{"", nil},
+		{"null", nil},
+
+		// booleans
+		{`true`, true},
+		{`false`, false},
+		{`on`, true},
+		{`off`, false},
+
+		// unsigned numbers
+		{`23`, uint64(23)},
+
+		// negative number
+		{`-42`, int64(-42)},
+
+		// floating point
+		{`3.14`, float64(3.14)},
+
+		// strings
+		{`'single quoted'`, `single quoted`},
+		{`'single quoted \"'`, `single quoted \"`},
+		{`"double quoted"`, `double quoted`},
+		{`"double quoted \""`, `double quoted "`},
+		{`plain string`, `plain string`},
+
+		// test arrays
+		{`[]`, nil},
+		{
+			`[array, 1, true, "abc"]`,
+			[]interface{}{"array", uint64(1), true, "abc"},
+		},
+		{
+			`[test, [1,2,3], on]`,
+			[]interface{}{
+				"test",
+				[]interface{}{uint64(1), uint64(2), uint64(3)},
+				true,
+			},
+		},
+
+		// test dictionaries:
+		{`{}`, nil},
+		{`{'key1': true,
+       "key2": 1,
+       key 3: ['test', "test2", off],
+       nested key: {"a" : 2}}`,
+			map[string]interface{}{
+				"key1":  true,
+				"key2":  uint64(1),
+				"key 3": []interface{}{"test", "test2", false},
+				"nested key": map[string]interface{}{
+					"a": uint64(2),
+				},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("run test (%v): %v", i, test.input)
+
+		v, err := parseValue(test.input)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		assert.Equal(t, test.expected, v)
+	}
+
+}
+
+func TestFlagValueParsingFails(t *testing.T) {
+	tests := []string{
+		// strings:
+		`'abc`,
+		`"abc`,
+
+		// arrays
+		`[1,2,3`,         // missing ']'
+		`['abc' 'def']`,  // missing comma
+		`['abc', 'def,]`, // nested
+
+		// objects
+		`{a: 1, b:2`,      // missing '}'
+		`{'a' 1, b: 2}`,   // missing ':'
+		`{'a': '1' b: 2}`, // missing ','
+		`{'abc: 2}`,       // key parsing error
+		`{key: 'fail}`,    // value parsing error
+		`{:'abc'}`,        // object with missing key
+		`{nested: {a: 2}`, // nested object with missing '}'
+	}
+	for i, test := range tests {
+		t.Logf("run test(%v): %v", i, test)
+
+		_, err := parseValue(test)
+		if err == nil {
+			t.Errorf("parsing '%v' did not fail", test)
+			continue
+		}
+
+		t.Log("  Failed with: ", err.Error())
+	}
+}

--- a/flag/value.go
+++ b/flag/value.go
@@ -2,7 +2,6 @@ package flag
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/elastic/go-ucfg"
@@ -32,6 +31,7 @@ func NewFlagKeyValue(cfg *ucfg.Config, autoBool bool, opts ...ucfg.Option) *Flag
 	return newFlagValue(cfg, opts, func(arg string) (*ucfg.Config, error, error) {
 		var key string
 		var val interface{}
+		var err error
 
 		args := strings.SplitN(arg, "=", 2)
 		if len(args) < 2 {
@@ -44,39 +44,14 @@ func NewFlagKeyValue(cfg *ucfg.Config, autoBool bool, opts ...ucfg.Option) *Flag
 			val = true
 		} else {
 			key = args[0]
-			val = parseCLIValue(args[1])
+			val, err = parseValue(args[1])
+			if err != nil {
+				return nil, err, err
+			}
 		}
 
 		tmp := map[string]interface{}{key: val}
 		cfg, err := ucfg.NewFrom(tmp, opts...)
 		return cfg, err, err
 	})
-}
-
-func parseCLIValue(value string) interface{} {
-	if b, ok := parseBoolValue(value); ok {
-		return b
-	}
-
-	if n, err := strconv.ParseUint(value, 0, 64); err == nil {
-		return n
-	}
-	if n, err := strconv.ParseInt(value, 0, 64); err == nil {
-		return n
-	}
-	if n, err := strconv.ParseFloat(value, 64); err == nil {
-		return n
-	}
-
-	return value
-}
-
-func parseBoolValue(str string) (value bool, ok bool) {
-	switch str {
-	case "1", "t", "T", "true", "TRUE", "True", "on", "ON":
-		return true, true
-	case "0", "f", "F", "false", "FALSE", "False", "off", "OFF":
-		return false, true
-	}
-	return false, false
 }


### PR DESCRIPTION
Enhance flag value parser to accept a superset of JSON, so arrays and objects
can be configured from commandline

The parser implements a superset of JSON, but only a subset of YAML by
allowing for arrays and objects having a trailing comma. In addition 3
strings types are supported:

1. single quoted string (no unescaping of any characters)
2. double quoted strings (characters are escaped)
3. strings without quotes. String parsing stops in
  special characters like '[]{},:'