### PR TITLE
Unpacker interface fixes and enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Syntax for passing lists and dictionaries to flags. #72
+- Add Unpacker interface specializations for primitive types. #73
 - Variable expansion parsing lists and dictionaries with parser introduced in
   #72. #74
 
@@ -16,6 +17,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+- Fix Unpacker interface not applied if some 'old' value is already present on
+  target and is struct implementing Unpack. #73
 
 ## [0.3.7]
 

--- a/reify_test.go
+++ b/reify_test.go
@@ -1,69 +1,10 @@
 package ucfg
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-type stUnpackable struct {
-	value int
-}
-
-type primUnpackable int
-
-func unpackI(v interface{}) (int, error) {
-	switch n := v.(type) {
-	case int64:
-		return int(n), nil
-	case uint64:
-		return int(n), nil
-	case float64:
-		return int(n), nil
-	}
-
-	m, ok := v.(map[string]interface{})
-	if !ok {
-		return 0, errors.New("expected dictionary")
-	}
-
-	val, ok := m["i"]
-	if !ok {
-		return 0, errors.New("missing field i")
-	}
-
-	switch n := val.(type) {
-	case int64:
-		return int(n), nil
-	case uint64:
-		return int(n), nil
-	case float64:
-		return int(n), nil
-	default:
-		return 0, errors.New("not a number")
-	}
-}
-
-func (s *stUnpackable) Unpack(v interface{}) error {
-	i, err := unpackI(v)
-	s.value = i
-	return err
-}
-
-func (s *stUnpackable) Value() int {
-	return s.value
-}
-
-func (p *primUnpackable) Unpack(v interface{}) error {
-	i, err := unpackI(v)
-	*p = primUnpackable(i)
-	return err
-}
-
-func (p primUnpackable) Value() int {
-	return int(p)
-}
 
 func TestUnpackPrimitiveValues(t *testing.T) {
 	tests := []interface{}{
@@ -509,24 +450,6 @@ func TestUnpackInline(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, true, b)
 	}
-}
-
-func TestReifyUnpackerInterface(t *testing.T) {
-	cfg, _ := NewFrom(map[string]interface{}{
-		"i": 10,
-	})
-
-	st := stUnpackable{}
-	err := cfg.Unpack(&st)
-	assert.NoError(t, err)
-	assert.Equal(t, 10, st.Value())
-
-	p := struct {
-		I primUnpackable
-	}{}
-	err = cfg.Unpack(&p)
-	assert.NoError(t, err)
-	assert.Equal(t, 10, p.I.Value())
 }
 
 func TestUnpackUnknown(t *testing.T) {

--- a/ucfg.go
+++ b/ucfg.go
@@ -38,16 +38,6 @@ type Meta struct {
 	Source string
 }
 
-// Unpacker type used by Unpack to allow types to implement custom configuration
-// unpacking.
-type Unpacker interface {
-	// Unpack is called if a setting of field has a type implementing Unpacker.
-	//
-	// The interface{} value passed to Unpack can be of type: bool, int64, uint64,
-	// float64, string, []interface{} or map[string]interface{}.
-	Unpack(interface{}) error
-}
-
 var (
 	tConfig         = reflect.TypeOf(Config{})
 	tConfigPtr      = reflect.PtrTo(tConfig)
@@ -55,7 +45,6 @@ var (
 	tInterfaceArray = reflect.TypeOf([]interface{}(nil))
 
 	// interface types
-	tUnpacker  = reflect.TypeOf((*Unpacker)(nil)).Elem()
 	tValidator = reflect.TypeOf((*Validator)(nil)).Elem()
 
 	// primitives

--- a/unpack.go
+++ b/unpack.go
@@ -1,0 +1,165 @@
+package ucfg
+
+import "reflect"
+
+// Unpacker type used by Unpack to allow types to implement custom configuration
+// unpacking.
+type Unpacker interface {
+	// Unpack is called if a setting of field has a type implementing Unpacker.
+	//
+	// The interface{} value passed to Unpack can be of type: bool, int64, uint64,
+	// float64, string, []interface{} or map[string]interface{}.
+	Unpack(interface{}) error
+}
+
+// BoolUnpacker interface specializes the Unpacker interface
+// by casting values to bool when calling Unpack.
+type BoolUnpacker interface {
+	Unpack(b bool) error
+}
+
+// IntUnpacker interface specializes the Unpacker interface
+// by casting values to int64 when calling Unpack.
+type IntUnpacker interface {
+	Unpack(i int64) error
+}
+
+// UintUnpacker interface specializes the Unpacker interface
+// by casting values to uint64 when calling Unpack.
+type UintUnpacker interface {
+	Unpack(u uint64) error
+}
+
+// FloatUnpacker interface specializes the Unpacker interface
+// by casting values to float64 when calling Unpack.
+type FloatUnpacker interface {
+	Unpack(f float64) error
+}
+
+// StringUnpacker interface specializes the Unpacker interface
+// by casting values to string when calling Unpack.
+type StringUnpacker interface {
+	Unpack(s string) error
+}
+
+// ConfigUnpacker interface specializes the Unpacker interface
+// by passing the the *Config object directly instead of
+// transforming the *Config object into map[string]interface{}.
+type ConfigUnpacker interface {
+	Unpack(c *Config) error
+}
+
+var (
+	// unpacker interface types
+	tUnpacker       = reflect.TypeOf((*Unpacker)(nil)).Elem()
+	tBoolUnpacker   = reflect.TypeOf((*BoolUnpacker)(nil)).Elem()
+	tIntUnpacker    = reflect.TypeOf((*IntUnpacker)(nil)).Elem()
+	tUintUnpacker   = reflect.TypeOf((*UintUnpacker)(nil)).Elem()
+	tFloatUnpacker  = reflect.TypeOf((*FloatUnpacker)(nil)).Elem()
+	tStringUnpacker = reflect.TypeOf((*StringUnpacker)(nil)).Elem()
+	tConfigUnpacker = reflect.TypeOf((*ConfigUnpacker)(nil)).Elem()
+
+	tUnpackers = [...]reflect.Type{
+		tUnpacker,
+		tBoolUnpacker,
+		tIntUnpacker,
+		tUintUnpacker,
+		tFloatUnpacker,
+		tStringUnpacker,
+		tConfigUnpacker,
+	}
+)
+
+// valueIsUnpacker checks if v implements the Unpacker interface.
+// If there exists a pointer to v, the pointer to v is also tested.
+func valueIsUnpacker(v reflect.Value) (reflect.Value, bool) {
+	for {
+		if implementsUnpacker(v.Type()) {
+			return v, true
+		}
+
+		if !v.CanAddr() {
+			break
+		}
+		v = v.Addr()
+	}
+
+	return reflect.Value{}, false
+}
+
+func typeIsUnpacker(t reflect.Type) (reflect.Value, bool) {
+	if implementsUnpacker(t) {
+		return reflect.New(t).Elem(), true
+	}
+
+	if implementsUnpacker(reflect.PtrTo(t)) {
+		return reflect.New(t), true
+	}
+
+	return reflect.Value{}, false
+}
+
+func implementsUnpacker(t reflect.Type) bool {
+	for _, tUnpack := range tUnpackers {
+		if t.Implements(tUnpack) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func unpackWith(opts *options, v reflect.Value, with value) Error {
+	ctx := with.Context()
+	meta := with.meta()
+
+	var err error
+	switch u := v.Interface().(type) {
+	case Unpacker:
+		var reified interface{}
+		if reified, err = with.reify(opts); err == nil {
+			err = u.Unpack(reified)
+		}
+
+	case BoolUnpacker:
+		var b bool
+		if b, err = with.toBool(opts); err == nil {
+			err = u.Unpack(b)
+		}
+
+	case IntUnpacker:
+		var n int64
+		if n, err = with.toInt(opts); err == nil {
+			err = u.Unpack(n)
+		}
+
+	case UintUnpacker:
+		var n uint64
+		if n, err = with.toUint(opts); err == nil {
+			err = u.Unpack(n)
+		}
+
+	case FloatUnpacker:
+		var f float64
+		if f, err = with.toFloat(opts); err == nil {
+			err = u.Unpack(f)
+		}
+
+	case StringUnpacker:
+		var s string
+		if s, err = with.toString(opts); err == nil {
+			err = u.Unpack(s)
+		}
+
+	case ConfigUnpacker:
+		var c *Config
+		if c, err = with.toConfig(opts); err == nil {
+			err = u.Unpack(c)
+		}
+	}
+
+	if err != nil {
+		return raisePathErr(err, meta, "", ctx.path("."))
+	}
+	return nil
+}

--- a/unpack_test.go
+++ b/unpack_test.go
@@ -1,0 +1,182 @@
+package ucfg
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type stUnpackable struct {
+	value int
+}
+
+type primUnpackable int
+
+type (
+	unpackBool   struct{ b bool }
+	unpackInt    struct{ i int }
+	unpackUint   struct{ u int }
+	unpackFloat  struct{ f float64 }
+	unpackString struct{ s string }
+	unpackConfig struct{ c *Config }
+)
+
+func (u *unpackBool) Unpack(b bool) error      { u.b = b; return nil }
+func (u *unpackInt) Unpack(i int64) error      { u.i = int(i); return nil }
+func (u *unpackUint) Unpack(v uint64) error    { u.u = int(v); return nil }
+func (u *unpackFloat) Unpack(f float64) error  { u.f = f; return nil }
+func (u *unpackString) Unpack(s string) error  { u.s = s; return nil }
+func (u *unpackConfig) Unpack(c *Config) error { u.c = c; return nil }
+
+func (s *stUnpackable) Unpack(v interface{}) error {
+	i, err := unpackI(v)
+	s.value = i
+	return err
+}
+
+func (s *stUnpackable) Value() int {
+	return s.value
+}
+
+func (p *primUnpackable) Unpack(v interface{}) error {
+	i, err := unpackI(v)
+	*p = primUnpackable(i)
+	return err
+}
+
+func (p primUnpackable) Value() int {
+	return int(p)
+}
+
+func unpackI(v interface{}) (int, error) {
+	switch n := v.(type) {
+	case int64:
+		return int(n), nil
+	case uint64:
+		return int(n), nil
+	case float64:
+		return int(n), nil
+	}
+
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return 0, errors.New("expected dictionary")
+	}
+
+	val, ok := m["i"]
+	if !ok {
+		return 0, errors.New("missing field i")
+	}
+
+	switch n := val.(type) {
+	case int64:
+		return int(n), nil
+	case uint64:
+		return int(n), nil
+	case float64:
+		return int(n), nil
+	default:
+		return 0, errors.New("not a number")
+	}
+}
+
+func TestReifyUnpackerInterface(t *testing.T) {
+	cfg, _ := NewFrom(map[string]interface{}{
+		"i": 10,
+	})
+
+	st := stUnpackable{}
+	err := cfg.Unpack(&st)
+	assert.NoError(t, err)
+	assert.Equal(t, 10, st.Value())
+
+	p := struct {
+		I primUnpackable
+	}{}
+	err = cfg.Unpack(&p)
+	assert.NoError(t, err)
+	assert.Equal(t, 10, p.I.Value())
+}
+
+func TestReifyUnpackers(t *testing.T) {
+	to := &struct {
+		B unpackBool
+		I unpackInt
+		U unpackUint
+		F unpackFloat
+		S unpackString
+		C unpackConfig
+	}{}
+
+	sub, _ := NewFrom(map[string]interface{}{"v": 1})
+	configs := []map[string]interface{}{
+		{"b": true},
+		{"i": -42},
+		{"u": 23},
+		{"f": 3.14},
+		{"s": "string"},
+		{"c": sub},
+	}
+
+	// apply configurations
+	for _, c := range configs {
+		cfg, err := NewFrom(c)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cfg.Unpack(to); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// validate unpackers
+	assert.Equal(t, true, to.B.b)
+	assert.Equal(t, -42, to.I.i)
+	assert.Equal(t, 23, to.U.u)
+	assert.Equal(t, 3.14, to.F.f)
+	assert.Equal(t, "string", to.S.s)
+	assert.Equal(t, sub, to.C.c)
+}
+
+func TestReifyUnpackersPtr(t *testing.T) {
+	to := &struct {
+		B *unpackBool
+		I *unpackInt
+		U *unpackUint
+		F *unpackFloat
+		S *unpackString
+		C *unpackConfig
+	}{}
+
+	sub, _ := NewFrom(map[string]interface{}{"v": 1})
+	configs := []map[string]interface{}{
+		{"b": true},
+		{"i": -42},
+		{"u": 23},
+		{"f": 3.14},
+		{"s": "string"},
+		{"c": sub},
+	}
+
+	// apply configurations
+	for _, c := range configs {
+		cfg, err := NewFrom(c)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cfg.Unpack(to); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// validate unpackers
+	assert.Equal(t, true, to.B.b)
+	assert.Equal(t, -42, to.I.i)
+	assert.Equal(t, 23, to.U.u)
+	assert.Equal(t, 3.14, to.F.f)
+	assert.Equal(t, "string", to.S.s)
+	assert.Equal(t, sub, to.C.c)
+}

--- a/util.go
+++ b/util.go
@@ -131,37 +131,3 @@ func isFloat(k reflect.Kind) bool {
 		return false
 	}
 }
-
-func implementsUnpacker(v reflect.Value) (reflect.Value, bool) {
-	for {
-		if v.Type().Implements(tUnpacker) {
-			return v, true
-		}
-
-		if !v.CanAddr() {
-			break
-		}
-		v = v.Addr()
-	}
-	return reflect.Value{}, false
-}
-
-func typeIsUnpacker(t reflect.Type) (reflect.Value, bool) {
-	if t.Implements(tUnpacker) {
-		return reflect.New(t).Elem(), true
-	}
-
-	if reflect.PtrTo(t).Implements(tUnpacker) {
-		return reflect.New(t), true
-	}
-
-	return reflect.Value{}, false
-}
-
-func unpackWith(ctx context, meta *Meta, v reflect.Value, with interface{}) Error {
-	err := v.Interface().(Unpacker).Unpack(with)
-	if err != nil {
-		return raisePathErr(err, meta, "", ctx.path("."))
-	}
-	return nil
-}


### PR DESCRIPTION
- Add Unpacker interface specializations for primitive types.
  Types can implement `Unpack(bool)`, `Unpack(string)`, ... directly,
  with casting and type checks being done ucfg. See unpack_test.go for some samples.

- Fix Unpacker interface not applied if some 'old' value is already present on
  target and is struct implementing Unpack.

  e.g.
  ```
  type config struct {
      V *myCustomConfig
  }

  func (m *myCustomConfig) Unpack(v interface{}) error { ... }
  ```

  if V in this struct is pre-initialized by non-nil value, the Unpack method
  was not called. Instead Unpack might actually fail, if myCustomConfig
  requires an primitive value like int or string.

  This has been fixed by moving the Unpacker interface test before reflection
  based unpacking.