### PR TITLE
Refactor and enhance environment variable parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Add per element type stop set for handling unquoted strings (reduces need for quoting strings in environment variables) #80
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+- fix issue unpacking array from environment variable into struct array fields #80
+- fix unparsed values being used for unpacking #80
 
 ## [0.4.2]
 

--- a/error.go
+++ b/error.go
@@ -166,7 +166,11 @@ func raiseDuplicateKey(cfg *Config, name string) Error {
 
 func raiseMissing(c *Config, field string) Error {
 	// error reading field from config, as missing in c
-	return raisePathErr(ErrMissing, c.metadata, "", c.PathOf(field, "."))
+	return raiseMissingMsg(c, field, "")
+}
+
+func raiseMissingMsg(c *Config, field string, message string) Error {
+	return raisePathErr(ErrMissing, c.metadata, message, c.PathOf(field, "."))
 }
 
 func raiseMissingArr(ctx context, meta *Meta, idx int) Error {

--- a/error_test.go
+++ b/error_test.go
@@ -45,6 +45,11 @@ func TestErrorMessages(t *testing.T) {
 		"missing_nested_wo_meta": raiseMissing(cNested, "field"),
 		"missing_nested_w_meta":  raiseMissing(cNestedMeta, "field"),
 
+		"missing_msg_wo_meta":        raiseMissingMsg(c, "field", "custom error message"),
+		"missing_msg_w_meta":         raiseMissingMsg(cMeta, "field", "custom error message"),
+		"missing_msg_nested_wo_meta": raiseMissingMsg(cNested, "field", "custom error message"),
+		"missing_msg_nested_w_meta":  raiseMissingMsg(cNestedMeta, "field", "custom error message"),
+
 		"arr_missing_wo_meta":        raiseMissingArr(context{}, nil, 5),
 		"arr_missing_w_meta":         raiseMissingArr(context{}, testMeta, 5),
 		"arr_missing_nested_wo_meta": raiseMissingArr(testNestedCtx, nil, 5),

--- a/flag/value.go
+++ b/flag/value.go
@@ -45,7 +45,7 @@ func NewFlagKeyValue(cfg *ucfg.Config, autoBool bool, opts ...ucfg.Option) *Flag
 			val = true
 		} else {
 			key = args[0]
-			val, err = parse.ParseValue(args[1])
+			val, err = parse.Value(args[1])
 			if err != nil {
 				return nil, err, err
 			}

--- a/internal/parse/parse_test.go
+++ b/internal/parse/parse_test.go
@@ -64,6 +64,13 @@ func TestFlagValueParsing(t *testing.T) {
 				true,
 			},
 		},
+		{
+			`[host1:1234, host2:1234]`,
+			[]interface{}{
+				"host1:1234",
+				"host2:1234",
+			},
+		},
 
 		// test dictionaries:
 		{`{}`, nil},
@@ -98,7 +105,7 @@ func TestFlagValueParsing(t *testing.T) {
 	for i, test := range tests {
 		t.Logf("run test (%v): %v", i, test.input)
 
-		v, err := ParseValue(test.input)
+		v, err := Value(test.input)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -132,7 +139,7 @@ func TestFlagValueParsingFails(t *testing.T) {
 	for i, test := range tests {
 		t.Logf("run test(%v): %v", i, test)
 
-		_, err := ParseValue(test)
+		_, err := Value(test)
 		if err == nil {
 			t.Errorf("parsing '%v' did not fail", test)
 			continue

--- a/reify.go
+++ b/reify.go
@@ -486,8 +486,7 @@ func castArr(opts *options, v value) ([]value, Error) {
 	if ref, ok := v.(*cfgDynamic); ok {
 		unrefed, err := ref.getValue(opts)
 		if err != nil {
-			// TODO: improve error message
-			return nil, raiseMissing(ref.ctx.getParent(), ref.dyn.String())
+			return nil, raiseMissingMsg(ref.ctx.getParent(), ref.ctx.field, err.Error())
 		}
 
 		if sub, ok := unrefed.(cfgSub); ok {

--- a/reify.go
+++ b/reify.go
@@ -483,10 +483,11 @@ func castArr(opts *options, v value) ([]value, Error) {
 	if sub, ok := v.(cfgSub); ok {
 		return sub.c.fields.array(), nil
 	}
-	if ref, ok := v.(*cfgRef); ok {
-		unrefed, err := ref.resolve(opts)
+	if ref, ok := v.(*cfgDynamic); ok {
+		unrefed, err := ref.getValue(opts)
 		if err != nil {
-			return nil, raiseMissing(ref.ctx.getParent(), ref.ref.String())
+			// TODO: improve error message
+			return nil, raiseMissing(ref.ctx.getParent(), ref.dyn.String())
 		}
 
 		if sub, ok := unrefed.(cfgSub); ok {

--- a/structs_test.go
+++ b/structs_test.go
@@ -1,0 +1,141 @@
+package ucfg
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testEnv map[string]string
+
+func TestStructMergeUnpackTyped(t *testing.T) {
+	type test struct {
+		t   interface{}
+		cfg interface{}
+		env testEnv
+	}
+
+	tests := []test{
+		{
+			t: &struct {
+				Strings []string
+			}{
+				Strings: []string{"string1", "abc"},
+			},
+			cfg: map[string]interface{}{
+				"strings": "${env_strings}",
+			},
+			env: testEnv{"env_strings": "string1,abc"},
+		},
+		{
+			t: &struct {
+				Strings []string
+			}{
+				Strings: []string{"string1", "abc"},
+			},
+			cfg: map[string]interface{}{
+				"strings": "${env_strings:string1,abc}",
+			},
+		},
+		{
+			t: &struct {
+				Strings []string
+			}{
+				Strings: []string{"one string"},
+			},
+			cfg: map[string]interface{}{
+				"strings": "${env_strings} string",
+			},
+			env: testEnv{"env_strings": "one"},
+		},
+
+		{
+			t: &struct {
+				Hosts []string
+			}{
+				Hosts: []string{"host1:1234", "host2:4567"},
+			},
+			cfg: map[string]interface{}{
+				"hosts": "${hosts_from_env}",
+			},
+			env: testEnv{"hosts_from_env": "host1:1234,host2:4567"},
+		},
+		{
+			t: &struct {
+				Hosts []string
+			}{
+				Hosts: []string{"host1:1234", "host2:4567"},
+			},
+			cfg: map[string]interface{}{
+				"hosts": "${missing_env:host1:1234,host2:4567}",
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("run test (%v): %v, %v", i, test.t, test.cfg)
+
+		opts := []Option{
+			VarExp,
+			resolveTestEnv(test.env),
+		}
+
+		// unpack input
+		c, err := NewFrom(test.t, opts...)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// compute expected outcome
+		var expected map[string]interface{}
+		if err := c.Unpack(&expected, opts...); err != nil {
+			t.Fatal(err)
+		}
+
+		// reset test.t to zero value
+		v := chaseValue(reflect.ValueOf(test.t))
+		v.Set(reflect.Zero(v.Type()))
+
+		// create new config from test
+		t.Logf("new from: %v", test.cfg)
+		if c, err = NewFrom(test.cfg, opts...); err != nil {
+			t.Fatal(err)
+		}
+
+		// unpack config into zeroed out config
+		if err := c.Unpack(test.t, opts...); err != nil {
+			t.Fatal(err)
+		}
+
+		// parse restored input config
+		if c, err = NewFrom(test.t, opts...); err != nil {
+			t.Fatal(err)
+		}
+
+		// validate
+		var actual map[string]interface{}
+		if err := c.Unpack(&actual, opts...); err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, expected, actual)
+	}
+}
+
+func resolveTestEnv(e testEnv) Option {
+	fail := func(name string) (string, error) {
+		return "", fmt.Errorf("empty environment variable %v", name)
+	}
+
+	if e == nil {
+		return Resolve(fail)
+	}
+	return Resolve(func(name string) (string, error) {
+		if v := e[name]; v != "" {
+			return v, nil
+		}
+		return fail(name)
+	})
+}

--- a/testdata/error/message/missing_msg_nested_w_meta.golden
+++ b/testdata/error/message/missing_msg_nested_w_meta.golden
@@ -1,0 +1,1 @@
+custom error message accessing 'nested.field' (source:'test.source')

--- a/testdata/error/message/missing_msg_nested_wo_meta.golden
+++ b/testdata/error/message/missing_msg_nested_wo_meta.golden
@@ -1,0 +1,1 @@
+custom error message accessing 'nested.field'

--- a/testdata/error/message/missing_msg_w_meta.golden
+++ b/testdata/error/message/missing_msg_w_meta.golden
@@ -1,0 +1,1 @@
+custom error message accessing 'field' (source:'test.source')

--- a/testdata/error/message/missing_msg_wo_meta.golden
+++ b/testdata/error/message/missing_msg_wo_meta.golden
@@ -1,0 +1,1 @@
+custom error message accessing 'field'

--- a/variables.go
+++ b/variables.go
@@ -87,7 +87,7 @@ func (r *reference) String() string {
 	return fmt.Sprintf("${%v}", r.Path)
 }
 
-func (r *reference) resolve(cfg *Config, opts *options) (value, error) {
+func (r *reference) resolveRef(cfg *Config, opts *options) (value, error) {
 	env := opts.env
 	var err error
 
@@ -114,7 +114,12 @@ func (r *reference) resolve(cfg *Config, opts *options) (value, error) {
 		env = env[:len(env)-1]
 	}
 
-	// try callbacks
+	return nil, err
+}
+
+func (r *reference) resolveEnv(cfg *Config, opts *options) (string, error) {
+	var err error
+
 	if len(opts.resolvers) > 0 {
 		key := r.Path.String()
 		for i := len(opts.resolvers) - 1; i >= 0; i-- {
@@ -122,12 +127,26 @@ func (r *reference) resolve(cfg *Config, opts *options) (value, error) {
 			resolver := opts.resolvers[i]
 			v, err = resolver(key)
 			if err == nil {
-				return newString(context{field: key}, nil, v), nil
+				return v, nil
 			}
 		}
 	}
 
-	return nil, err
+	return "", err
+}
+
+func (r *reference) resolve(cfg *Config, opts *options) (value, error) {
+	v, err := r.resolveRef(cfg, opts)
+	if v != nil || err != nil {
+		return v, err
+	}
+
+	s, err := r.resolveEnv(cfg, opts)
+	if s == "" || err != nil {
+		return nil, err
+	}
+
+	return newString(context{field: r.Path.String()}, nil, s), nil
 }
 
 func (r *reference) eval(cfg *Config, opts *options) (string, error) {


### PR DESCRIPTION
- Add per element type stop set for handling unquoted strings (reduces need for
  quoting strings in environment variables)
- Add more tests for merging and unpacking into typed structs
- rename parse.ParseValue to parse.Value
- factor out value cache in separate type for use with cfgDynamic
- Unify cfgRef and cfgSplice into cfgDynamic:
  - guarantees consisten behavior
  - fixes some minor unpacking issues of yet unparsed values

- fix: issue unpacking array from environment variable into struct array fields
- fix: if setting is environment variable from single reference only, parse the resolved string