### PR TITLE
Add support for pure array config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Add support for pure array config files #82 
 
 ### Changed
 
@@ -13,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+- Fix panic when merging or creating a config from nil interface value #82
 
 ## [0.4.3]
 

--- a/error.go
+++ b/error.go
@@ -186,11 +186,11 @@ func raiseIndexOutOfBounds(opts *options, value value, idx int) Error {
 	return raisePathErr(reason, value.meta(), message, ctx.path("."))
 }
 
-func raiseInvalidTopLevelType(v interface{}) Error {
-	// most likely developers fault
+func raiseInvalidTopLevelType(v interface{}, meta *Meta) Error {
+	// could be developers or user fault
 	t := chaseTypePointers(chaseValue(reflect.ValueOf(v)).Type())
-	message := fmt.Sprintf("can not use go type '%v' for merging/unpacking configurations", t)
-	return raiseCritical(ErrTypeMismatch, message)
+	message := fmt.Sprintf("type '%v' is not supported on top level of config, only dictionary or list", t)
+	return raiseErr(ErrTypeMismatch, messageMeta(message, meta))
 }
 
 func raiseKeyInvalidTypeUnpack(t reflect.Type, from *Config) Error {

--- a/error_test.go
+++ b/error_test.go
@@ -70,7 +70,8 @@ func TestErrorMessages(t *testing.T) {
 		"invalid_regexp_w_meta": raiseInvalidRegexp(newString(
 			context{field: "regex"}, testMeta, ""), regexpErr),
 
-		"invalid_type_top_level": raiseInvalidTopLevelType(""),
+		"invalid_type_top_level_w_meta":  raiseInvalidTopLevelType("", testMeta),
+		"invalid_type_top_level_wo_meta": raiseInvalidTopLevelType("", nil),
 
 		"invalid_type_unpack_wo_meta": raiseKeyInvalidTypeUnpack(
 			reflect.TypeOf(map[int]interface{}{}), c),

--- a/flag/util.go
+++ b/flag/util.go
@@ -35,7 +35,7 @@ func (v *FlagValue) String() string {
 	if v.collector == nil {
 		return ""
 	}
-	
+
 	return toString(v.Config(), v.collector.GetOptions(), v.onError)
 }
 

--- a/json/json.go
+++ b/json/json.go
@@ -8,7 +8,7 @@ import (
 )
 
 func NewConfig(in []byte, opts ...ucfg.Option) (*ucfg.Config, error) {
-	var m map[string]interface{}
+	var m interface{}
 	if err := json.Unmarshal(in, &m); err != nil {
 		return nil, err
 	}

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -79,3 +79,30 @@ func TestNestedPath(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, verify.C.B)
 }
+
+func TestArray(t *testing.T) {
+	input := []byte(`
+[
+  {
+    "b": 2,
+    "c": 3
+  },
+  {
+    "c": 4
+  }
+]
+`)
+
+	c, err := NewConfig(input)
+	if err != nil {
+		t.Fatalf("failed to parse input: %v", err)
+	}
+
+	verify := []map[string]int{}
+	err = c.Unpack(&verify)
+	assert.Nil(t, err)
+
+	assert.Equal(t, verify[0]["b"], 2)
+	assert.Equal(t, verify[0]["c"], 3)
+	assert.Equal(t, verify[1]["c"], 4)
+}

--- a/merge.go
+++ b/merge.go
@@ -48,6 +48,11 @@ import (
 // well. Passing cyclic structures to Merge will result in an infinite recursive
 // loop.
 func (c *Config) Merge(from interface{}, options ...Option) error {
+	// from is empty in case of empty config file
+	if from == nil {
+		return nil
+	}
+
 	opts := makeOptions(options)
 	other, err := normalize(opts, from)
 
@@ -179,7 +184,7 @@ func normalize(opts *options, from interface{}) (*Config, Error) {
 
 	}
 
-	return nil, raiseInvalidTopLevelType(from)
+	return nil, raiseInvalidTopLevelType(from, opts.meta)
 }
 
 func normalizeMap(opts *options, from reflect.Value) (*Config, Error) {

--- a/reify.go
+++ b/reify.go
@@ -142,7 +142,7 @@ func reifyInto(opts *options, to reflect.Value, from *Config) Error {
 		return nil
 	}
 
-	return raiseInvalidTopLevelType(to.Interface())
+	return raiseInvalidTopLevelType(to.Interface(), opts.meta)
 }
 
 func reifyMap(opts *options, to reflect.Value, from *Config) Error {

--- a/testdata/error/message/invalid_type_top_level.golden
+++ b/testdata/error/message/invalid_type_top_level.golden
@@ -1,1 +1,0 @@
-(assert) can not use go type 'string' for merging/unpacking configurations

--- a/testdata/error/message/invalid_type_top_level_w_meta.golden
+++ b/testdata/error/message/invalid_type_top_level_w_meta.golden
@@ -1,0 +1,1 @@
+type 'string' is not supported on top level of config, only dictionary or list (source:'test.source')

--- a/testdata/error/message/invalid_type_top_level_wo_meta.golden
+++ b/testdata/error/message/invalid_type_top_level_wo_meta.golden
@@ -1,0 +1,1 @@
+type 'string' is not supported on top level of config, only dictionary or list

--- a/yaml/yaml.go
+++ b/yaml/yaml.go
@@ -3,15 +3,17 @@ package yaml
 import (
 	"io/ioutil"
 
-	"github.com/elastic/go-ucfg"
 	"gopkg.in/yaml.v2"
+
+	"github.com/elastic/go-ucfg"
 )
 
 func NewConfig(in []byte, opts ...ucfg.Option) (*ucfg.Config, error) {
-	var m map[string]interface{}
+	var m interface{}
 	if err := yaml.Unmarshal(in, &m); err != nil {
 		return nil, err
 	}
+
 	return ucfg.NewFrom(m, opts...)
 }
 

--- a/yaml/yaml_test.go
+++ b/yaml/yaml_test.go
@@ -75,3 +75,24 @@ func TestNestedPath(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, verify.C.B)
 }
+
+func TestArray(t *testing.T) {
+	input := []byte(`
+- b: 2
+  c: 3
+- c: 4
+`)
+
+	c, err := NewConfig(input)
+	if err != nil {
+		t.Fatalf("failed to parse input: %v", err)
+	}
+
+	verify := []map[string]int{}
+	err = c.Unpack(&verify)
+	assert.Nil(t, err)
+
+	assert.Equal(t, verify[0]["b"], 2)
+	assert.Equal(t, verify[0]["c"], 3)
+	assert.Equal(t, verify[1]["c"], 4)
+}


### PR DESCRIPTION
This change adds support for config file which do not start with a map[string]interface{}. Example:

```
- module: system
  metricsets: ["cpu"]
- module: system
  metricsets: ["processes"]
```

The above does not have a `metricbeat.modules:` as a top entry.

Further changes:

* Prevent panic on empty config files
* Run `go fmt`