### PR TITLE
Fix merging dynamically generated sub-configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- merging sub-configs enforces strict variable expansion #85
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+- fix merging nil sub-configs #85
 
 ## [0.4.4]
 

--- a/merge.go
+++ b/merge.go
@@ -76,27 +76,13 @@ func mergeConfigDict(opts *options, to, from *Config) Error {
 			field:  k,
 		}
 
-		old, ok := to.fields.get(k)
-		if !ok {
-			to.fields.set(k, v.cpy(ctx))
-			continue
-		}
-
-		subOld, err := old.toConfig(opts)
+		old, _ := to.fields.get(k)
+		merged, err := mergeValues(opts, old, v)
 		if err != nil {
-			to.fields.set(k, v.cpy(ctx))
-			continue
-		}
-
-		subFrom, err := v.toConfig(opts)
-		if err != nil {
-			to.fields.set(k, v.cpy(ctx))
-			continue
-		}
-
-		if err := mergeConfig(opts, subOld, subFrom); err != nil {
 			return err
 		}
+
+		to.fields.set(k, merged.cpy(ctx))
 	}
 	return nil
 }
@@ -114,23 +100,13 @@ func mergeConfigArr(opts *options, to, from *Config) Error {
 			field:  fmt.Sprintf("%v", i),
 		}
 
-		v := from.fields.array()[i]
-
 		old := to.fields.array()[i]
-		subOld, err := old.toConfig(opts)
+		v := from.fields.array()[i]
+		merged, err := mergeValues(opts, old, v)
 		if err != nil {
-			to.fields.setAt(i, cfgSub{to}, v.cpy(ctx))
-			continue
-		}
-
-		subFrom, err := v.toConfig(opts)
-		if err != nil {
-			to.fields.setAt(i, cfgSub{to}, v.cpy(ctx))
-		}
-
-		if err := mergeConfig(opts, subOld, subFrom); err != nil {
 			return err
 		}
+		to.fields.setAt(i, cfgSub{to}, merged.cpy(ctx))
 	}
 
 	end := len(from.fields.array())
@@ -149,6 +125,30 @@ func mergeConfigArr(opts *options, to, from *Config) Error {
 	}
 
 	return nil
+}
+
+func mergeValues(opts *options, old, v value) (value, Error) {
+	if old == nil {
+		return v, nil
+	}
+
+	// check if new and old value evaluate to sub-configurations. If one is no
+	// sub-configuration, use new value only.
+	subOld, err := old.toConfig(opts)
+	if err != nil {
+		return v, nil
+	}
+	subV, err := v.toConfig(opts)
+	if err != nil {
+		return v, nil
+	}
+
+	// merge new and old evaluated sub-configurations and return subOld for
+	// reassigning to old key in case of subOld being generated dynamically
+	if err := mergeConfig(opts, subOld, subV); err != nil {
+		return nil, err
+	}
+	return cfgSub{subOld}, nil
 }
 
 // convert from into normalized *Config checking for errors


### PR DESCRIPTION
reassign key of merged sub-configs to ensure config objects generated
dynamically will be correctly merged.

=> merging sub-configs enforces strict variable expansion of settings
   being affected