### PR TITLE
Add support to ignore struct fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Introduce ,ignore struct tag option to optionally ignore exported fields. #89
 
 ### Changed
 
@@ -13,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+- Ignore private struct fields when merging a struct into a config. #89
 
 ## [0.4.5]
 

--- a/merge_test.go
+++ b/merge_test.go
@@ -374,23 +374,23 @@ func TestMergeChildArray(t *testing.T) {
 }
 
 func TestMergeSquash(t *testing.T) {
-	type subType struct{ B bool }
-	type subInterface struct{ B interface{} }
+	type SubType struct{ B bool }
+	type SubInterface struct{ B interface{} }
 
 	tests := []interface{}{
 		&struct {
-			C subType `config:",squash"`
-		}{subType{true}},
+			C SubType `config:",squash"`
+		}{SubType{true}},
 		&struct {
-			subType `config:",squash"`
-		}{subType{true}},
+			SubType `config:",squash"`
+		}{SubType{true}},
 
 		&struct {
-			C subInterface `config:",squash"`
-		}{subInterface{true}},
+			C SubInterface `config:",squash"`
+		}{SubInterface{true}},
 		&struct {
-			subInterface `config:",squash"`
-		}{subInterface{true}},
+			SubInterface `config:",squash"`
+		}{SubInterface{true}},
 
 		&struct {
 			C map[string]bool `config:",squash"`
@@ -402,9 +402,6 @@ func TestMergeSquash(t *testing.T) {
 
 		&struct {
 			C node `config:",squash"`
-		}{node{"b": true}},
-		&struct {
-			node `config:",squash"`
 		}{node{"b": true}},
 	}
 

--- a/reify.go
+++ b/reify.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"regexp"
 	"time"
+	"unicode"
+	"unicode/utf8"
 )
 
 // Unpack unpacks c into a struct, a map, or a slice allocating maps, slices,
@@ -56,6 +58,9 @@ import (
 //  A field its name is set using the `config` struct tag (configured by StructTag)
 //  If tag is missing or no field name is configured in the tag, the field name
 //  itself will be used.
+//  If the tag sets the `,ignore` flag, the field will not be overwritten.
+//  If the tag sets the `,inline` or `,squash` flag, Unpack will apply the current
+//  configuration namespace to the fields.
 //
 //
 // Fields available in a struct or a map, but not in the Config object, will not
@@ -197,9 +202,17 @@ func reifyStruct(opts *options, orig reflect.Value, cfg *Config) Error {
 		numField := to.NumField()
 		for i := 0; i < numField; i++ {
 			stField := to.Type().Field(i)
-			vField := to.Field(i)
-			name, tagOpts := parseTags(stField.Tag.Get(opts.tag))
 
+			// ignore non exported fields
+			if rune, _ := utf8.DecodeRuneInString(stField.Name); !unicode.IsUpper(rune) {
+				continue
+			}
+			name, tagOpts := parseTags(stField.Tag.Get(opts.tag))
+			if tagOpts.ignore {
+				continue
+			}
+
+			vField := to.Field(i)
 			validators, err := parseValidatorTags(stField.Tag.Get(opts.validatorTag))
 			if err != nil {
 				return raiseCritical(err, "")

--- a/util.go
+++ b/util.go
@@ -7,6 +7,7 @@ import (
 
 type tagOptions struct {
 	squash bool
+	ignore bool
 }
 
 var noTagOpts = tagOptions{}
@@ -18,6 +19,8 @@ func parseTags(tag string) (string, tagOptions) {
 		switch opt {
 		case "squash", "inline":
 			opts.squash = true
+		case "ignore":
+			opts.ignore = true
 		}
 	}
 	return s[0], opts


### PR DESCRIPTION
- Fix: ignore non-exported fields when merging a struct into a config
- Introduce `,ignore` struct tag option to optionally ignore exported fields