### PR TITLE
Add support for reflection based Unpacker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Introduce ,ignore struct tag option to optionally ignore exported fields. #89
+- Add support for custom Unpacker method with `*Config` being convertible to first parameter. The custom method must be compatible to `ConfigUnpacker`. #90
 
 ### Changed
 

--- a/ucfg.go
+++ b/ucfg.go
@@ -45,6 +45,7 @@ var (
 	tInterfaceArray = reflect.TypeOf([]interface{}(nil))
 
 	// interface types
+	tError     = reflect.TypeOf((*error)(nil)).Elem()
 	tValidator = reflect.TypeOf((*Validator)(nil)).Elem()
 
 	// primitives


### PR DESCRIPTION
go-ucfg allows for custom typed unpackers via interfaces `BoolUnpacker`,
`IntUnpacker`, ..., `ConfigUnpacker`.

In case of the `ucfg.Config` object being rebranded, the `ConfigUnpacker`
interfaces is not usable. This change uses reflection to support some rebranded
unpacker by checking `*Config` being convertible to the first method parameter.
The interface expected must still be compatible to `ConfigUnpacker`.

With this change, this sample code can be used to unpack using a customized
config type:

```
type MyConfig *ucfg.Config

type ConcreteConfig struct {
    ...
}

func (c *ConcreteConfig) Unpack(in *MyConfig) error {
    ...
}
```