### PR TITLE
Better handling of cyclic reference and top level reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Detect cyclic reference and allow to search top level key with the other resolvers. #97
 - Allow to diff keys of two different configuration #93
 
 ### Changed

--- a/error.go
+++ b/error.go
@@ -44,6 +44,8 @@ type criticalError struct {
 var (
 	ErrMissing = errors.New("missing field")
 
+	ErrCyclicReference = errors.New("cyclic reference detected")
+
 	ErrDuplicateValidator = errors.New("validator already registered")
 
 	ErrTypeNoArray = errors.New("field is no array")
@@ -162,6 +164,16 @@ func messagePath(reason error, meta *Meta, message, path string) string {
 
 func raiseDuplicateKey(cfg *Config, name string) Error {
 	return raisePathErr(ErrDuplicateKeey, cfg.metadata, "", cfg.PathOf(name, "."))
+}
+
+func raiseCyclicErr(field string) Error {
+	message := fmt.Sprintf("cyclic reference detected for key: '%s'", field)
+
+	return baseError{
+		reason:  ErrCyclicReference,
+		class:   ErrConfig,
+		message: message,
+	}
 }
 
 func raiseMissing(c *Config, field string) Error {

--- a/errpred.go
+++ b/errpred.go
@@ -1,0 +1,24 @@
+package ucfg
+
+func isCyclicError(err error) bool {
+	switch v := err.(type) {
+	case Error:
+		return v.Reason() == ErrCyclicReference
+	}
+	return false
+}
+
+func isMissingError(err error) bool {
+	switch v := err.(type) {
+	case Error:
+		return v.Reason() == ErrMissing
+	}
+	return false
+}
+
+func criticalResolveError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return !(isCyclicError(err) || isMissingError(err))
+}

--- a/errpred_test.go
+++ b/errpred_test.go
@@ -1,0 +1,43 @@
+package ucfg
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCriticalResolveError(t *testing.T) {
+	tests := []struct {
+		title    string
+		err      Error
+		expected bool
+	}{
+		{
+			title:    "error is ErrMissing",
+			err:      raiseMissing(New(), "reference"),
+			expected: false,
+		},
+		{
+			title:    "error is ErrCyclicReference",
+			err:      raiseCyclicErr("reference"),
+			expected: false,
+		},
+		{
+			title:    "any other error is critical",
+			err:      raiseCritical(errors.New("something bad"), ""),
+			expected: true,
+		},
+		{
+			title:    "when the error is nil",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			assert.Equal(t, test.expected, criticalResolveError(test.err))
+		})
+	}
+}

--- a/fieldset.go
+++ b/fieldset.go
@@ -1,0 +1,43 @@
+package ucfg
+
+type fieldSet struct {
+	fields map[string]struct{}
+	parent *fieldSet
+}
+
+func NewFieldSet(parent *fieldSet) *fieldSet {
+	return &fieldSet{
+		fields: map[string]struct{}{},
+		parent: parent,
+	}
+}
+
+func (s *fieldSet) Has(name string) (exists bool) {
+	if _, exists = s.fields[name]; !exists && s.parent != nil {
+		exists = s.parent.Has(name)
+	}
+	return
+}
+
+func (s *fieldSet) Add(name string) {
+	s.fields[name] = struct{}{}
+}
+
+func (s *fieldSet) AddNew(name string) (ok bool) {
+	if ok = !s.Has(name); ok {
+		s.Add(name)
+	}
+	return
+}
+
+func (s *fieldSet) Names() []string {
+	var names []string
+	for k := range s.fields {
+		names = append(names, k)
+	}
+
+	if s.parent != nil {
+		names = append(names, s.parent.Names()...)
+	}
+	return names
+}

--- a/fieldset_test.go
+++ b/fieldset_test.go
@@ -1,0 +1,60 @@
+package ucfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFieldsetAddAField(t *testing.T) {
+	fs := NewFieldSet(nil)
+	fs.Add("hello")
+	assert.True(t, fs.Has("hello"))
+}
+
+func TestFieldsetReturnsTheListOfFields(t *testing.T) {
+	fs1 := NewFieldSet(nil)
+	fs1.Add("hello")
+	fs1.Add("bye")
+	fs2 := NewFieldSet(fs1)
+	fs2.Add("adios")
+	assert.ElementsMatch(t, []string{"hello", "bye", "adios"}, fs2.Names())
+}
+
+func TestFieldSetHas(t *testing.T) {
+	fs1 := NewFieldSet(nil)
+	fs1.Add("parent")
+	fs2 := NewFieldSet(fs1)
+	fs2.Add("child")
+
+	t.Run("ParentHasField", func(t *testing.T) {
+		assert.True(t, fs2.Has("parent"))
+	})
+
+	t.Run("ChildAndParentDontHaveTheField", func(t *testing.T) {
+		assert.False(t, fs2.Has("parent-doesnt"))
+	})
+
+	t.Run("ChildHasField", func(t *testing.T) {
+		assert.True(t, fs2.Has("child"))
+	})
+}
+
+func TestFieldSetAddNew(t *testing.T) {
+	fs1 := NewFieldSet(nil)
+	fs1.Add("parent")
+	fs2 := NewFieldSet(fs1)
+	fs2.Add("child")
+
+	t.Run("ParentHasField", func(t *testing.T) {
+		assert.False(t, fs2.AddNew("parent"))
+	})
+
+	t.Run("ChildAndParentDontHaveTheField", func(t *testing.T) {
+		assert.True(t, fs2.AddNew("none"))
+	})
+
+	t.Run("ChildHasField", func(t *testing.T) {
+		assert.False(t, fs2.AddNew("child"))
+	})
+}

--- a/reify.go
+++ b/reify.go
@@ -151,6 +151,9 @@ func reifyInto(opts *options, to reflect.Value, from *Config) Error {
 }
 
 func reifyMap(opts *options, to reflect.Value, from *Config) Error {
+	parentFields := opts.activeFields
+	defer func() { opts.activeFields = parentFields }()
+
 	if to.Type().Key().Kind() != reflect.String {
 		return raiseKeyInvalidTypeUnpack(to.Type(), from)
 	}
@@ -164,6 +167,7 @@ func reifyMap(opts *options, to reflect.Value, from *Config) Error {
 		to.Set(reflect.MakeMap(to.Type()))
 	}
 	for k, value := range fields {
+		opts.activeFields = NewFieldSet(parentFields)
 		key := reflect.ValueOf(k)
 
 		old := to.MapIndex(key)
@@ -186,6 +190,9 @@ func reifyMap(opts *options, to reflect.Value, from *Config) Error {
 }
 
 func reifyStruct(opts *options, orig reflect.Value, cfg *Config) Error {
+	parentFields := opts.activeFields
+	defer func() { opts.activeFields = parentFields }()
+
 	orig = chaseValuePointers(orig)
 
 	to := chaseValuePointers(reflect.New(chaseTypePointers(orig.Type())))
@@ -211,6 +218,8 @@ func reifyStruct(opts *options, orig reflect.Value, cfg *Config) Error {
 			if tagOpts.ignore {
 				continue
 			}
+
+			opts.activeFields = NewFieldSet(parentFields)
 
 			vField := to.Field(i)
 			validators, err := parseValidatorTags(stField.Tag.Get(opts.validatorTag))

--- a/testdata/error/message/cyclic_reference.golden
+++ b/testdata/error/message/cyclic_reference.golden
@@ -1,0 +1,1 @@
+cyclic reference detected for key: 'top.key'

--- a/types.go
+++ b/types.go
@@ -35,6 +35,7 @@ type value interface {
 	toUint(opts *options) (uint64, error)
 	toFloat(opts *options) (float64, error)
 	toConfig(opts *options) (*Config, error)
+	canCache() bool
 }
 
 type typeInfo struct {
@@ -183,6 +184,7 @@ func (cfgPrimitive) toInt(*options) (int64, error)      { return 0, ErrTypeMisma
 func (cfgPrimitive) toUint(*options) (uint64, error)    { return 0, ErrTypeMismatch }
 func (cfgPrimitive) toFloat(*options) (float64, error)  { return 0, ErrTypeMismatch }
 func (cfgPrimitive) toConfig(*options) (*Config, error) { return nil, ErrTypeMismatch }
+func (cfgPrimitive) canCache() bool                     { return true }
 
 func (c *cfgNil) cpy(ctx context) value             { return &cfgNil{cfgPrimitive{ctx, c.metadata}} }
 func (*cfgNil) Len(*options) (int, error)           { return 0, nil }
@@ -284,6 +286,7 @@ func (cfgSub) toInt(*options) (int64, error)        { return 0, ErrTypeMismatch 
 func (cfgSub) toUint(*options) (uint64, error)      { return 0, ErrTypeMismatch }
 func (cfgSub) toFloat(*options) (float64, error)    { return 0, ErrTypeMismatch }
 func (c cfgSub) toConfig(*options) (*Config, error) { return c.c, nil }
+func (c cfgSub) canCache() bool                     { return false }
 
 func (c cfgSub) Len(*options) (int, error) {
 	arr := c.c.fields.array()
@@ -344,6 +347,9 @@ func (c cfgSub) SetContext(ctx context) {
 }
 
 func (c cfgSub) reify(opts *options) (interface{}, error) {
+	parentFields := opts.activeFields
+	defer func() { opts.activeFields = parentFields }()
+
 	fields := c.c.fields.dict()
 	arr := c.c.fields.array()
 
@@ -353,6 +359,7 @@ func (c cfgSub) reify(opts *options) (interface{}, error) {
 	case len(fields) > 0 && len(arr) == 0:
 		m := make(map[string]interface{})
 		for k, v := range fields {
+			opts.activeFields = NewFieldSet(parentFields)
 			var err error
 			if m[k], err = v.reify(opts); err != nil {
 				return nil, err
@@ -362,6 +369,7 @@ func (c cfgSub) reify(opts *options) (interface{}, error) {
 	case len(fields) == 0 && len(arr) > 0:
 		m := make([]interface{}, len(arr))
 		for i, v := range arr {
+			opts.activeFields = NewFieldSet(parentFields)
 			var err error
 			if m[i], err = v.reify(opts); err != nil {
 				return nil, err
@@ -371,12 +379,14 @@ func (c cfgSub) reify(opts *options) (interface{}, error) {
 	default:
 		m := make(map[string]interface{})
 		for k, v := range fields {
+			opts.activeFields = NewFieldSet(parentFields)
 			var err error
 			if m[k], err = v.reify(opts); err != nil {
 				return nil, err
 			}
 		}
 		for i, v := range arr {
+			opts.activeFields = NewFieldSet(parentFields)
 			var err error
 			m[fmt.Sprintf("%d", i)], err = v.reify(opts)
 			if err != nil {
@@ -474,6 +484,10 @@ func (d *cfgDynamic) getValue(opts *options) (value, error) {
 	})
 }
 
+func (d cfgDynamic) canCache() bool {
+	return false
+}
+
 func (r *refDynValue) String() string {
 	ref := (*reference)(r)
 	return ref.String()
@@ -485,12 +499,20 @@ func (r *refDynValue) getValue(
 ) (value, error) {
 	ref := (*reference)(r)
 	v, err := ref.resolveRef(p.ctx.getParent(), opts)
-	if v != nil || err != nil {
+	// If not found or we have a cyclic reference we try the environment resolvers
+	if v != nil || criticalResolveError(err) {
 		return v, err
 	}
+	previousErr := err
 
 	str, err := ref.resolveEnv(p.ctx.getParent(), opts)
 	if err != nil {
+		// TODO(ph): Not everything is an Error, will do some cleanup in another PR.
+		if v, ok := previousErr.(Error); ok {
+			if v.Reason() == ErrCyclicReference {
+				return nil, previousErr
+			}
+		}
 		return nil, err
 	}
 	return parseValue(p, opts, str)

--- a/ucfg_test.go
+++ b/ucfg_test.go
@@ -1,11 +1,18 @@
 package ucfg
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+var opts = []Option{
+	PathSep("."),
+	ResolveEnv,
+	VarExp,
+}
 
 func TestFlattenKeys(t *testing.T) {
 	tests := []struct {
@@ -58,6 +65,179 @@ func TestFlattenKeys(t *testing.T) {
 				t.Fatal(err)
 			}
 			assert.Equal(t, expected, sorted(c.FlattenedKeys(opts...)))
+		})
+	}
+}
+
+func TestDetectCyclicReference(t *testing.T) {
+	tests := []struct {
+		title  string
+		cfg    map[string]interface{}
+		config interface{}
+	}{
+		{
+			title: "direct reference on a struct",
+			cfg: map[string]interface{}{
+				"top.reference": "${top.reference}",
+			},
+			config: &struct {
+				TopReference string `config:"top.reference"`
+			}{},
+		},
+		{
+			title: "direct compound reference on a struct",
+			cfg: map[string]interface{}{
+				"top.reference": "hello ${top.reference}",
+			},
+			config: &struct {
+				TopReference string `config:"top.reference"`
+			}{},
+		},
+		{
+			title: "direct template reference on an empty map",
+			cfg: map[string]interface{}{
+				"top.reference": "hello ${top.reference}",
+			},
+			config: &map[string]interface{}{},
+		},
+		{
+			title: "indirect template reference on an empty map",
+			cfg: map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": map[string]interface{}{
+						"c": "hello ${a}",
+					},
+				},
+			},
+			config: &map[string]interface{}{},
+		},
+		{
+			title: "indirect reference on an empty map",
+			cfg: map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": map[string]interface{}{
+						"c": "${a}",
+					},
+				},
+			},
+			config: &map[string]interface{}{},
+		},
+		{
+			title: "direct array reference into an empty map",
+			cfg: map[string]interface{}{
+				"c": []string{
+					"a",
+					"${c.1}",
+				},
+			},
+			config: &map[string]interface{}{},
+		},
+		{
+			title: "direct array reference into an empty map",
+			cfg: map[string]interface{}{
+				"c": []string{
+					"a",
+					"${c.1}",
+				},
+			},
+			config: &map[string]interface{}{},
+		},
+		{
+			title: "direct array reference into a struct",
+			cfg: map[string]interface{}{
+				"c": []string{
+					"a",
+					"${c.1}",
+				},
+			},
+			config: &struct {
+				C []string `config:"c"`
+			}{},
+		},
+	}
+
+	for _, test := range tests {
+
+		t.Run(test.title, func(t *testing.T) {
+			c, err := NewFrom(test.cfg, opts...)
+			assert.NoError(t, err)
+
+			err = c.Unpack(test.config, opts...)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestCyclicReferenceShouldFallbackToOtherResolvers(t *testing.T) {
+	cfg := map[string]interface{}{
+		"top.reference": "${top.reference}",
+	}
+
+	resolveFn := func(key string) (string, error) {
+		if key == "top.reference" {
+			return "reference-found", nil
+		}
+		return "", ErrMissing
+	}
+
+	opts := []Option{
+		PathSep("."),
+		Resolve(resolveFn),
+		ResolveEnv,
+		VarExp,
+	}
+
+	c, err := NewFrom(cfg, opts...)
+	v, err := c.String("top.reference", -1, opts...)
+	if assert.NoError(t, err) {
+		assert.Equal(t, "reference-found", v)
+	}
+}
+
+func TestTopYamlKeyInEnvResolvers(t *testing.T) {
+	resolveFn := func(key string) (string, error) {
+		if key == "a.key" {
+			return "key-found", nil
+		}
+		return "", fmt.Errorf("could not find the key: %s", key)
+	}
+
+	opts := []Option{
+		PathSep("."),
+		Resolve(resolveFn),
+		ResolveEnv,
+		VarExp,
+	}
+
+	tests := []struct {
+		name     string
+		cfg      interface{}
+		expected string
+	}{
+		{
+			name: "top level key reference exists",
+			cfg: map[string]interface{}{
+				"a.top":         "top-level",
+				"f.l.reference": "${a.key}",
+			},
+		},
+		{
+			name: "top level key reference doesn't exist",
+			cfg: map[string]interface{}{
+				"f.l.reference": "${a.key}",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c, err := NewFrom(test.cfg, opts...)
+			assert.NoError(t, err)
+
+			v, err := c.String("f.l.reference", -1, opts...)
+			if assert.NoError(t, err) {
+				assert.Equal(t, "key-found", v)
+			}
 		})
 	}
 }

--- a/variables_test.go
+++ b/variables_test.go
@@ -1,6 +1,7 @@
 package ucfg
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -53,18 +54,12 @@ func TestVarExpParserSuccess(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Logf("test %v: %v", test.title, test.exp)
-		actual, err := parseSplice(test.exp, ".")
-		if err != nil {
-			t.Errorf("  failed to parse with %v", err)
-			continue
-		}
-
-		t.Logf("  expected: %v", test.expected)
-		t.Logf("  actual: %v", actual)
-		if assert.Equal(t, test.expected, actual) {
-			t.Logf("  success")
-		}
+		t.Run(fmt.Sprintf("%s %s", test.title, test.exp), func(t *testing.T) {
+			actual, err := parseSplice(test.exp, ".")
+			if assert.NoError(t, err) {
+				assert.Equal(t, test.expected, actual)
+			}
+		})
 	}
 }
 
@@ -75,10 +70,10 @@ func TestVarExpParseErrors(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Logf("test %v: %v", test.title, test.exp)
-		res, err := parseSplice(test.exp, ".")
-		t.Logf("  result: %v", res)
-		t.Logf("  error: %v", err)
-		assert.True(t, err != nil)
+		t.Run(fmt.Sprintf("test %v: %v", test.title, test.exp), func(t *testing.T) {
+			res, err := parseSplice(test.exp, ".")
+			assert.True(t, err != nil)
+			assert.Error(t, err, fmt.Sprintf("result: %v, error: %v", res, err))
+		})
 	}
 }


### PR DESCRIPTION
*Cyclic reference*

This commits changes the behavior of the ucfg library when we detect
cyclic reference, before when a cyclic was defined in a configuration
the library would go into an infinite loop and panic because of the
stack.

The new behavior is the following, when a cyclic reference is detected
when resolving the reference it will try to resolve it with the other
configured resolvers (the environment and the keystore for beats). If the key
is not found in theses resolvers the error will be send back to the
users with the problematic key.

If the values is found in the other resolver it will return that value
and it wont be a cyclic reference.

The detection is using a `VisitedFieldsRecorder` that will keep track of
the paths that was required to generate the concrete value, if the path is see
twice we return an error.

The caching behavior of the types was changed to only take care of primitives
values an not cfgDynamic.

*Top level reference*

Change of behavior in the `resolveRef`, it will now return ErrMissing
when a top level key is not found so the key can be check with the other
resolvers.