### PR TITLE
Fix an issue when a cyclic reference was incorrectly detected when multiple reference was used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+- Fix: an issue with the Cyclic reference algorithm when a direct reference was pointing
+  to another reference. #100
 
 ## [0.5.0]
 

--- a/reify.go
+++ b/reify.go
@@ -576,11 +576,14 @@ func doReifyPrimitive(
 		tRegexp:   reifyRegexp,
 	}
 
+	previous := opts.opts.activeFields
+	opts.opts.activeFields = NewFieldSet(previous)
 	valT, err := val.typ(opts.opts)
 	if err != nil {
 		ctx := val.Context()
 		return reflect.Value{}, raisePathErr(err, val.meta(), "", ctx.path("."))
 	}
+	opts.opts.activeFields = previous
 
 	// try primitive conversion
 	kind := baseType.Kind()


### PR DESCRIPTION
Fix was to make sure when we call `doReifyPrimitives` we need to clear
fields before tring to make the value concrete, because this will
require to revisited some fields to generate the actual values.

Problematic structure
```
{
  "path": {
    "home": "/var",
    "logs" "${path.home}"
  }
  "output" : {
    "file": "${path.logs}"
  }
}
```

We could also improve the caching mechanism to solve that issues, but
this seems to be the simplest fix to do.

Fixes: elastic/beats#6214