### PR TITLE
Correct order when unpacking into ucfg.Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+- Fix: do not treat ucfg.Config (or castable type) as Unpacker. #106
 
 ## [0.5.1]
 

--- a/reify.go
+++ b/reify.go
@@ -399,14 +399,6 @@ func reifyMergeValue(
 
 	baseType := chaseTypePointers(old.Type())
 
-	if v, ok := valueIsUnpacker(old); ok {
-		err := unpackWith(opts.opts, v, val)
-		if err != nil {
-			return reflect.Value{}, err
-		}
-		return old, nil
-	}
-
 	if tConfig.ConvertibleTo(baseType) {
 		sub, err := val.toConfig(opts.opts)
 		if err != nil {
@@ -438,6 +430,14 @@ func reifyMergeValue(
 
 		// old != value -> merge value into old
 		return oldValue, mergeConfig(opts.opts, subOld, sub)
+	}
+
+	if v, ok := valueIsUnpacker(old); ok {
+		err := unpackWith(opts.opts, v, val)
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		return old, nil
 	}
 
 	switch baseType.Kind() {

--- a/unpack.go
+++ b/unpack.go
@@ -117,6 +117,12 @@ func typeIsUnpacker(t reflect.Type) (reflect.Value, bool) {
 }
 
 func implementsUnpacker(t reflect.Type) bool {
+	// ucfg.Config or structures that can be casted to ucfg.Config are not
+	// Unpackers.
+	if tConfig.ConvertibleTo(chaseTypePointers(t)) {
+		return false
+	}
+
 	for _, tUnpack := range tUnpackers {
 		if t.Implements(tUnpack) {
 			return true


### PR DESCRIPTION
Unpacking into a ucfg.Config (or convertible structure) has priority
over custom Unpack methods. Both, ucfg.Config and Unpacker interface
have an `Unpack` method with signature `Unpack(interface{}) error`. The
difference between these too is, `(*ucfg.Config).Unpack` gets the target
structure as parameter, while the `Unpacker` interface gets the config
as parameter and the target is the method receiver.

=> When testing for the Unpacker interface, we must first make sure the
   method receiver is not of type `ucfg.Config`.