### PR TITLE
Array merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Add *Config merging options merge, append, prepend, replace. #107
 
 ### Changed
 

--- a/merge.go
+++ b/merge.go
@@ -31,7 +31,7 @@ import (
 // Merge traverses the value from recursively copying all values into a hierarchy
 // of Config objects plus primitives into c.
 //
-// Merge supports the options: PathSep, MetaData, StructTag, VarExp
+// Merge supports the options: PathSep, MetaData, StructTag, VarExp, ReplaceValues, AppendValues, PrependValues
 //
 // Merge uses the type-dependent default encodings:
 //  - Boolean values are encoded as booleans.
@@ -92,7 +92,23 @@ func mergeConfig(opts *options, to, from *Config) Error {
 }
 
 func mergeConfigDict(opts *options, to, from *Config) Error {
-	for k, v := range from.fields.dict() {
+	dict := from.fields.dict()
+	if len(dict) == 0 {
+		return nil
+	}
+
+	ok := false
+	if opts.configValueHandling == cfgReplaceValue {
+		old := to.fields.dict()
+		to.fields.d = nil
+		defer func() {
+			if !ok {
+				to.fields.d = old
+			}
+		}()
+	}
+
+	for k, v := range dict {
 		ctx := context{
 			parent: cfgSub{to},
 			field:  k,
@@ -106,38 +122,74 @@ func mergeConfigDict(opts *options, to, from *Config) Error {
 
 		to.fields.set(k, merged.cpy(ctx))
 	}
+
+	ok = true
 	return nil
 }
 
 func mergeConfigArr(opts *options, to, from *Config) Error {
-	l := len(to.fields.array())
-	if l > len(from.fields.array()) {
-		l = len(from.fields.array())
+	switch opts.configValueHandling {
+	case cfgReplaceValue:
+		return mergeConfigReplaceArr(opts, to, from)
+
+	case cfgArrPrepend:
+		return mergeConfigPrependArr(opts, to, from)
+
+	case cfgArrAppend:
+		return mergeConfigAppendArr(opts, to, from)
+
+	case cfgDefaultHandling, cfgMergeValues:
+		return mergeConfigMergeArr(opts, to, from)
+	default:
+		return mergeConfigMergeArr(opts, to, from)
 	}
+}
+
+func mergeConfigReplaceArr(opts *options, to, from *Config) Error {
+	a := from.fields.array()
+	if len(a) == 0 {
+		return nil
+	}
+
+	var parent value = cfgSub{to}
+	var fields = fields{
+		d: to.fields.d,
+		a: make([]value, 0, len(a)),
+	}
+	fields.append(parent, a)
+	*to.fields = fields
+	return nil
+}
+
+func mergeConfigMergeArr(opts *options, to, from *Config) Error {
+	l := len(to.fields.array())
+	arr := from.fields.array()
+	if l > len(arr) {
+		l = len(arr)
+	}
+
+	var parent value = cfgSub{to}
 
 	// merge array indexes available in to and from
 	for i := 0; i < l; i++ {
 		ctx := context{
-			parent: cfgSub{to},
+			parent: parent,
 			field:  fmt.Sprintf("%v", i),
 		}
 
 		old := to.fields.array()[i]
-		v := from.fields.array()[i]
-		merged, err := mergeValues(opts, old, v)
+		merged, err := mergeValues(opts, old, arr[i])
 		if err != nil {
 			return err
 		}
-		to.fields.setAt(i, cfgSub{to}, merged.cpy(ctx))
+		to.fields.setAt(i, parent, merged.cpy(ctx))
 	}
 
-	end := len(from.fields.array())
-	if end <= l {
-		return nil
+	if len(arr) > l {
+		// add additional array entries not yet in 'to'
+		to.fields.append(parent, arr[l:])
 	}
-
-	// add additional array entries not yet in 'to'
-	return mergeConfigAppendArr(opts, to, from)
+	return nil
 }
 
 func mergeConfigPrependArr(opts *options, to, from *Config) Error {

--- a/merge.go
+++ b/merge.go
@@ -137,15 +137,29 @@ func mergeConfigArr(opts *options, to, from *Config) Error {
 	}
 
 	// add additional array entries not yet in 'to'
-	for ; l < end; l++ {
-		ctx := context{
-			parent: cfgSub{to},
-			field:  fmt.Sprintf("%v", l),
-		}
-		v := from.fields.array()[l]
-		to.fields.setAt(l, cfgSub{to}, v.cpy(ctx))
+	return mergeConfigAppendArr(opts, to, from)
+}
+
+func mergeConfigPrependArr(opts *options, to, from *Config) Error {
+	a1 := to.fields.array()
+	a2 := from.fields.array()
+	if len(a2) == 0 {
+		return nil
 	}
 
+	var parent value = cfgSub{to}
+	var fields = fields{
+		d: to.fields.d,
+		a: make([]value, 0, len(a1)+len(a2)),
+	}
+	fields.append(parent, a2)
+	fields.append(parent, a1)
+	*to.fields = fields
+	return nil
+}
+
+func mergeConfigAppendArr(opts *options, to, from *Config) Error {
+	to.fields.append(cfgSub{to}, from.fields.array())
 	return nil
 }
 

--- a/merge_test.go
+++ b/merge_test.go
@@ -950,3 +950,121 @@ func TestMergeNil(t *testing.T) {
 		assert.Equal(t, 42, int(i))
 	}
 }
+
+func TestMergeGlobalArrConfig(t *testing.T) {
+	type testCase struct {
+		options  []Option
+		in       []interface{}
+		expected interface{}
+	}
+
+	cases := map[string]testCase{
+		"merge array values": testCase{
+			in: []interface{}{
+				map[string]interface{}{
+					"a": []interface{}{
+						map[string]interface{}{"b": 1},
+					},
+				},
+				map[string]interface{}{
+					"a": []interface{}{
+						map[string]interface{}{"c": 2},
+						map[string]interface{}{"d": 3},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"a": []interface{}{
+					map[string]interface{}{"b": uint64(1), "c": uint64(2)},
+					map[string]interface{}{"d": uint64(3)},
+				},
+			},
+		},
+
+		"replace array values": testCase{
+			options: []Option{ReplaceValues},
+			in: []interface{}{
+				map[string]interface{}{
+					"a": []interface{}{
+						map[string]interface{}{"b": 1},
+					},
+				},
+				map[string]interface{}{
+					"a": []interface{}{
+						map[string]interface{}{"c": 2},
+						map[string]interface{}{"d": 3},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"a": []interface{}{
+					map[string]interface{}{"c": uint64(2)},
+					map[string]interface{}{"d": uint64(3)},
+				},
+			},
+		},
+
+		"append array values": testCase{
+			options: []Option{AppendValues},
+			in: []interface{}{
+				map[string]interface{}{
+					"a": []interface{}{
+						map[string]interface{}{"b": 1},
+					},
+				},
+				map[string]interface{}{
+					"a": []interface{}{
+						map[string]interface{}{"c": 2},
+						map[string]interface{}{"d": 3},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"a": []interface{}{
+					map[string]interface{}{"b": uint64(1)},
+					map[string]interface{}{"c": uint64(2)},
+					map[string]interface{}{"d": uint64(3)},
+				},
+			},
+		},
+
+		"prepend array values": testCase{
+			options: []Option{PrependValues},
+			in: []interface{}{
+				map[string]interface{}{
+					"a": []interface{}{
+						map[string]interface{}{"b": 1},
+					},
+				},
+				map[string]interface{}{
+					"a": []interface{}{
+						map[string]interface{}{"c": 2},
+						map[string]interface{}{"d": 3},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"a": []interface{}{
+					map[string]interface{}{"c": uint64(2)},
+					map[string]interface{}{"d": uint64(3)},
+					map[string]interface{}{"b": uint64(1)},
+				},
+			},
+		},
+	}
+
+	for name, test := range cases {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			cfg := New()
+			for _, in := range test.in {
+				err := cfg.Merge(in, test.options...)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			assertConfig(t, cfg, test.expected)
+		})
+	}
+}

--- a/opts.go
+++ b/opts.go
@@ -34,6 +34,8 @@ type options struct {
 	resolvers    []func(name string) (string, error)
 	varexp       bool
 
+	configValueHandling configHandling
+
 	// temporary cache of parsed splice values for lifetime of call to
 	// Unpack/Pack/Get/...
 	parsed valueCache
@@ -119,6 +121,29 @@ func doResolveEnv(o *options) {
 		}
 		return value, nil
 	})
+}
+
+var (
+	// ReplacesValues option configures all merging and unpacking operations to
+	// replace old dictionaries and arrays while merging. Value merging can be
+	// overwritten in unpack by using struct tags.
+	ReplaceValues = makeOptValueHandling(cfgReplaceValue)
+
+	// AppendValues option configures all merging and unpacking operations to
+	// merge dictionaries and append arrays to existing arrays while merging.
+	// Value merging can be overwritten in unpack by using struct tags.
+	AppendValues = makeOptValueHandling(cfgArrAppend)
+
+	// PrependValues option configures all merging and unpacking operations to
+	// merge dictionaries and prepend arrays to existing arrays while merging.
+	// Value merging can be overwritten in unpack by using struct tags.
+	PrependValues = makeOptValueHandling(cfgArrPrepend)
+)
+
+func makeOptValueHandling(h configHandling) Option {
+	return func(o *options) {
+		o.configValueHandling = h
+	}
 }
 
 // VarExp option enables support for variable expansion. Resolve and Env options will only be effective if  VarExp is set.

--- a/ucfg.go
+++ b/ucfg.go
@@ -83,6 +83,18 @@ func New() *Config {
 	}
 }
 
+// NustNewFrom creates a new config object normalizing and copying from into the new
+// Config object. MustNewFrom uses Merge to copy from.
+//
+// MustNewFrom supports the options: PathSep, MetaData, StructTag, VarExp
+func MustNewFrom(from interface{}, opts ...Option) *Config {
+	c := New()
+	if err := c.Merge(from, opts...); err != nil {
+		panic(err)
+	}
+	return c
+}
+
 // NewFrom creates a new config object normalizing and copying from into the new
 // Config object. NewFrom uses Merge to copy from.
 //
@@ -233,4 +245,20 @@ func (f *fields) setAt(idx int, parent, v value) {
 	}
 
 	f.a[idx] = v
+}
+
+func (f *fields) append(parent value, a []value) {
+	l := len(f.a)
+	count := len(a)
+	if count == 0 {
+		return
+	}
+
+	for i := 0; i < count; i, l = i+1, l+1 {
+		ctx := context{
+			parent: parent,
+			field:  fmt.Sprintf("%v", l),
+		}
+		f.setAt(l, parent, a[i].cpy(ctx))
+	}
 }

--- a/ucfg.go
+++ b/ucfg.go
@@ -262,3 +262,11 @@ func (f *fields) append(parent value, a []value) {
 		f.setAt(l, parent, a[i].cpy(ctx))
 	}
 }
+
+func (o *fieldOptions) configHandling() configHandling {
+	h := o.tag.cfgHandling
+	if h == cfgDefaultHandling {
+		h = o.opts.configValueHandling
+	}
+	return h
+}

--- a/util.go
+++ b/util.go
@@ -23,9 +23,21 @@ import (
 )
 
 type tagOptions struct {
-	squash bool
-	ignore bool
+	squash      bool
+	ignore      bool
+	cfgHandling configHandling
 }
+
+// configHandling configures the operation to execute if we merge into a struct
+// field that holds an unpacked config object.
+type configHandling uint8
+
+const (
+	cfgMerge configHandling = iota
+	cfgReplace
+	cfgAppend
+	cfgPrepend
+)
 
 var noTagOpts = tagOptions{}
 
@@ -38,6 +50,14 @@ func parseTags(tag string) (string, tagOptions) {
 			opts.squash = true
 		case "ignore":
 			opts.ignore = true
+		case "merge":
+			opts.cfgHandling = cfgMerge
+		case "replace":
+			opts.cfgHandling = cfgReplace
+		case "append":
+			opts.cfgHandling = cfgAppend
+		case "prepend":
+			opts.cfgHandling = cfgPrepend
 		}
 	}
 	return s[0], opts

--- a/util.go
+++ b/util.go
@@ -33,10 +33,11 @@ type tagOptions struct {
 type configHandling uint8
 
 const (
-	cfgMerge configHandling = iota
-	cfgReplace
-	cfgAppend
-	cfgPrepend
+	cfgDefaultHandling configHandling = iota
+	cfgMergeValues
+	cfgReplaceValue
+	cfgArrAppend
+	cfgArrPrepend
 )
 
 var noTagOpts = tagOptions{}
@@ -51,13 +52,13 @@ func parseTags(tag string) (string, tagOptions) {
 		case "ignore":
 			opts.ignore = true
 		case "merge":
-			opts.cfgHandling = cfgMerge
+			opts.cfgHandling = cfgMergeValues
 		case "replace":
-			opts.cfgHandling = cfgReplace
+			opts.cfgHandling = cfgReplaceValue
 		case "append":
-			opts.cfgHandling = cfgAppend
+			opts.cfgHandling = cfgArrAppend
 		case "prepend":
-			opts.cfgHandling = cfgPrepend
+			opts.cfgHandling = cfgArrPrepend
 		}
 	}
 	return s[0], opts


### PR DESCRIPTION
Improve array merging by configuring the 'merge' strategy either globally or via struct tags. Overwriting the merge option in a struct-tags will apply the merge rule for all sub-structures.

Merge rules:
- *merge (default)*: Merge values and values in arrays. Struct tag option: `merge`, global: none (default behavior)).
- *replace*: Replace *Config objects containing dicionaries or arrays. Struct tag option: `replace`, global: `ReplaceValues`.
- *append*: Merge dictionaries, but append arrays to existing arrays. Struct tag option: `append`, global: `AppendValues`.
- *prepend*: Merge dictionaries, but prepend arrays to existing arrays. Struct tag option: `prepend`, global: `PrependValues`.

