### PR TITLE
Fix escape character not removed from escaped string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+- Fix escape character not removed from escaped string #115
 
 ## [0.6.1]
 

--- a/merge.go
+++ b/merge.go
@@ -508,7 +508,7 @@ func normalizeString(ctx context, opts *options, str string) (value, Error) {
 
 	switch p := varexp.(type) {
 	case constExp:
-		return newString(ctx, opts.meta, str), nil
+		return newString(ctx, opts.meta, string(p)), nil
 	case *reference:
 		return newRef(ctx, opts.meta, p), nil
 	}

--- a/merge_test.go
+++ b/merge_test.go
@@ -566,6 +566,7 @@ func TestMergeSpliced(t *testing.T) {
 			"obj":     "{f1: ${one}, f2: ${two}}",
 			"strings": "${l},${s}",
 			"empty":   "",
+			"escaped": "$${escaped}",
 		},
 	}
 
@@ -608,6 +609,9 @@ func TestMergeSpliced(t *testing.T) {
 	e, err := c.String("sub.empty", -1, PathSep("."))
 	assert.NoError(t, err)
 
+	escaped, err := c.String("sub.escaped", -1, PathSep("."))
+	assert.NoError(t, err)
+
 	assert.Equal(t, true, b)
 	assert.Equal(t, 42, int(i))
 	assert.Equal(t, 23, int(u))
@@ -620,6 +624,7 @@ func TestMergeSpliced(t *testing.T) {
 	assert.Equal(t, "lazy", s0)
 	assert.Equal(t, "str", s1)
 	assert.Equal(t, "", e)
+	assert.Equal(t, "${escaped}", escaped)
 }
 
 func TestMergeVarExp(t *testing.T) {


### PR DESCRIPTION
When escaping `$`, the escape symbol should be removed when unpacking the configuration.