### PR TITLE
Adding a ResolverNOOP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Added a NOOP resolver that will return the key wrapped in the field reference syntax. #xxx
 
 ### Changed
 

--- a/opts.go
+++ b/opts.go
@@ -123,6 +123,19 @@ func doResolveEnv(o *options) {
 	})
 }
 
+// ResolveNOOP option add a resolver that will not search the value but instead will return the
+// provided key wrap with the field reference syntax. This is useful if you don't to expose values
+// from envionment variable or other resolvers.
+//
+// Example: "mysecret" => ${mysecret}"
+var ResolveNOOP Option = doResolveNOOP
+
+func doResolveNOOP(o *options) {
+	o.resolvers = append(o.resolvers, func(name string) (string, error) {
+		return "${" + name + "}", nil
+	})
+}
+
 var (
 	// ReplacesValues option configures all merging and unpacking operations to
 	// replace old dictionaries and arrays while merging. Value merging can be

--- a/ucfg_test.go
+++ b/ucfg_test.go
@@ -300,3 +300,23 @@ func TestMultipleDirectReference(t *testing.T) {
 		}
 	})
 }
+
+func TestResolveNOOP(t *testing.T) {
+	opts := []Option{
+		PathSep("."),
+		ResolveNOOP,
+	}
+
+	cfg := map[string]interface{}{
+		"a.top":         "top-level",
+		"f.l.reference": "${a.key}",
+	}
+
+	c, err := NewFrom(cfg, opts...)
+	assert.NoError(t, err)
+
+	v, err := c.String("f.l.reference", -1, opts...)
+	if assert.NoError(t, err) {
+		assert.Equal(t, "${a.key}", v)
+	}
+}


### PR DESCRIPTION
This resolver will return the key wrapped in the field reference syntax.
This allow you to hide sensitive information present in the environment
or by other resolvers.