### PR TITLE
Add (*Config).Remove method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Add (*Config).Has. #127
+- Add (*Config).Remove. #126
 
 ### Changed
 

--- a/error.go
+++ b/error.go
@@ -61,6 +61,8 @@ type criticalError struct {
 var (
 	ErrMissing = errors.New("missing field")
 
+	ErrNoParse = errors.New("parsing dynamic configs is disabled")
+
 	ErrCyclicReference = errors.New("cyclic reference detected")
 
 	ErrDuplicateValidator = errors.New("validator already registered")
@@ -257,6 +259,11 @@ func raiseUnsupportedInputType(ctx context, meta *Meta, v reflect.Value) Error {
 		v.Type(), v)
 
 	return raiseCritical(reason, messagePath(reason, meta, message, ctx.path(".")))
+}
+
+func raiseNoParse(ctx context, meta *Meta) Error {
+	reason := ErrNoParse
+	return raisePathErr(reason, meta, "", ctx.path("."))
 }
 
 func raiseNil(reason error) Error {

--- a/error_test.go
+++ b/error_test.go
@@ -138,6 +138,11 @@ func TestErrorMessages(t *testing.T) {
 		"unsupported_input_type_nested_w_meta": raiseUnsupportedInputType(
 			testNestedCtx, testMeta, reflect.ValueOf(1)),
 
+		"no_parse":               raiseNoParse(context{}, testMeta),
+		"no_parse_w_meta":        raiseNoParse(context{}, testMeta),
+		"no_parse_nested":        raiseNoParse(testNestedCtx, nil),
+		"no_parse_nested_w_meta": raiseNoParse(testNestedCtx, testMeta),
+
 		"nil_value_error":  raiseNil(ErrNilValue),
 		"nil_config_error": raiseNil(ErrNilConfig),
 
@@ -209,7 +214,7 @@ func TestErrorMessages(t *testing.T) {
 
 			tmp, err := ioutil.ReadFile(goldenFile)
 			if err != nil {
-				t.Fatalf("Failed to read golden file ('%v'): %v", goldenFile, err)
+				t.Fatalf("Failed to read golden file ('%v'): %v\nExpected contents: '%v'", goldenFile, err, message)
 			}
 
 			golden := string(tmp)

--- a/opts.go
+++ b/opts.go
@@ -33,6 +33,7 @@ type options struct {
 	env          []*Config
 	resolvers    []func(name string) (string, error)
 	varexp       bool
+	noParse      bool
 
 	configValueHandling configHandling
 

--- a/path.go
+++ b/path.go
@@ -32,6 +32,7 @@ type field interface {
 	String() string
 	SetValue(opt *options, elem value, v value) Error
 	GetValue(opt *options, elem value) (value, Error)
+	Remove(opt *options, elem value) (bool, Error)
 }
 
 type namedField struct {
@@ -248,4 +249,61 @@ func (i idxField) SetValue(opts *options, elem value, v value) Error {
 	sub.c.fields.setAt(i.i, elem, v)
 	v.SetContext(context{parent: elem, field: i.String()})
 	return nil
+}
+
+func (p cfgPath) Remove(cfg *Config, opt *options) (bool, error) {
+	fields := p.fields
+
+	// Loop over intermediate objects. Returns an error if any intermediate is
+	// actually no object.
+	cur := value(cfgSub{cfg})
+	for ; len(fields) > 1; fields = fields[1:] {
+		field := fields[0]
+		next, err := field.GetValue(opt, cur)
+		if err != nil {
+			// Ignore ErrMissing when walking down a config tree. If intermediary is
+			// missing we can't remove our setting.
+			if err.Reason() == ErrMissing {
+				err = nil
+			}
+
+			return false, err
+		}
+
+		if next == nil {
+			return false, err
+		}
+
+		cur = next
+	}
+
+	// resolve config object in case we deal with references
+	tmp, err := cur.toConfig(opt)
+	if err != nil {
+		return false, err
+	}
+	cur = cfgSub{tmp}
+
+	field := fields[0]
+	return field.Remove(opt, cur)
+}
+
+func (n namedField) Remove(opts *options, elem value) (bool, Error) {
+	sub, ok := elem.(cfgSub)
+	if !ok {
+		return false, raiseExpectedObject(opts, elem)
+	}
+
+	removed := sub.c.fields.del(n.name)
+	return removed, nil
+}
+
+func (i idxField) Remove(opts *options, elem value) (bool, Error) {
+	sub, ok := elem.(cfgSub)
+	if !ok {
+		return false, raiseExpectedObject(opts, elem)
+	}
+
+	removed := sub.c.fields.delAt(i.i)
+	return removed, nil
 }

--- a/testdata/error/message/no_parse.golden
+++ b/testdata/error/message/no_parse.golden
@@ -1,0 +1,1 @@
+parsing dynamic configs is disabled accessing config (source:'test.source')

--- a/testdata/error/message/no_parse_nested.golden
+++ b/testdata/error/message/no_parse_nested.golden
@@ -1,0 +1,1 @@
+parsing dynamic configs is disabled accessing 'nested'

--- a/testdata/error/message/no_parse_nested_w_meta.golden
+++ b/testdata/error/message/no_parse_nested_w_meta.golden
@@ -1,0 +1,1 @@
+parsing dynamic configs is disabled accessing 'nested' (source:'test.source')

--- a/testdata/error/message/no_parse_w_meta.golden
+++ b/testdata/error/message/no_parse_w_meta.golden
@@ -1,0 +1,1 @@
+parsing dynamic configs is disabled accessing config (source:'test.source')

--- a/types.go
+++ b/types.go
@@ -554,6 +554,10 @@ func (s spliceDynValue) String() string {
 }
 
 func parseValue(p *cfgPrimitive, opts *options, str string) (value, error) {
+	if opts.noParse {
+		return nil, raiseNoParse(p.ctx, p.meta())
+	}
+
 	ifc, err := parse.Value(str)
 	if err != nil {
 		return nil, err

--- a/ucfg_test.go
+++ b/ucfg_test.go
@@ -383,3 +383,105 @@ func TestHas(t *testing.T) {
 		})
 	}
 }
+
+func TestRemove(t *testing.T) {
+	type spec struct {
+		has   bool
+		fails bool
+		path  string
+		idx   int
+	}
+
+	cases := map[string]struct {
+		cfg   map[string]interface{}
+		wants map[string]interface{}
+		spec  spec
+	}{
+		"exist": {
+			cfg:   map[string]interface{}{"field": "test"},
+			wants: nil,
+			spec:  spec{has: true, path: "field", idx: -1},
+		},
+		"unknown field": {
+			cfg:   map[string]interface{}{"field": "test"},
+			wants: map[string]interface{}{"field": "test"},
+			spec:  spec{has: false, path: "unknown", idx: -1},
+		},
+		"nested": {
+			cfg:   map[string]interface{}{"a.b": "keep", "a.c": "remove"},
+			wants: map[string]interface{}{"a": map[string]interface{}{"b": "keep"}},
+			spec:  spec{has: true, path: "a.c", idx: -1},
+		},
+		"unknown nested": {
+			cfg:   map[string]interface{}{"a.b": "keep", "a.c": "keep"},
+			wants: map[string]interface{}{"a": map[string]interface{}{"b": "keep", "c": "keep"}},
+			spec:  spec{has: false, path: "a.d", idx: -1},
+		},
+		"array start": {
+			cfg:   map[string]interface{}{"arr": []interface{}{"a", "b", "c"}},
+			wants: map[string]interface{}{"arr": []interface{}{"b", "c"}},
+			spec:  spec{has: true, path: "arr", idx: 0},
+		},
+		"array end": {
+			cfg:   map[string]interface{}{"arr": []interface{}{"a", "b", "c"}},
+			wants: map[string]interface{}{"arr": []interface{}{"a", "b"}},
+			spec:  spec{has: true, path: "arr", idx: 2},
+		},
+		"array middle": {
+			cfg:   map[string]interface{}{"arr": []interface{}{"a", "b", "c"}},
+			wants: map[string]interface{}{"arr": []interface{}{"a", "c"}},
+			spec:  spec{has: true, path: "arr", idx: 1},
+		},
+		"array out of index": {
+			cfg:   map[string]interface{}{"arr": []interface{}{"a", "b", "c"}},
+			wants: map[string]interface{}{"arr": []interface{}{"a", "b", "c"}},
+			spec:  spec{has: false, path: "arr", idx: 5},
+		},
+		"full namespace": {
+			cfg:   map[string]interface{}{"a.b": 1, "a.c": 2, "x": "keep"},
+			wants: map[string]interface{}{"x": "keep"},
+			spec:  spec{has: true, path: "a", idx: -1},
+		},
+		"shared via reference": {
+			cfg: map[string]interface{}{"a": "${b}", "b.c": "remove", "b.d": "keep"},
+			wants: map[string]interface{}{
+				"a": map[string]interface{}{
+					"d": "keep",
+				},
+				"b": map[string]interface{}{
+					"d": "keep",
+				},
+			},
+			spec: spec{has: true, path: "a.c", idx: -1},
+		},
+		"fail if no object": {
+			cfg:  map[string]interface{}{"a": "test"},
+			spec: spec{fails: true, path: "a.b", idx: -1},
+		},
+	}
+
+	for name, test := range cases {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			opts := []Option{PathSep("."), VarExp}
+
+			cfg := MustNewFrom(test.cfg, opts...)
+			b, err := cfg.Remove(test.spec.path, test.spec.idx, opts...)
+			if err != nil && !test.spec.fails {
+				t.Fatal("unexpected error:", err)
+			}
+			assert.Equal(t, test.spec.has, b, "unexpected remove operation result")
+
+			if test.spec.fails {
+				return
+			}
+
+			var actual map[string]interface{}
+			if err := cfg.Unpack(&actual, opts...); err != nil {
+				t.Fatal("unpacking config after remove failed:", err)
+			}
+
+			assert.Equal(t, test.wants, actual)
+		})
+	}
+}


### PR DESCRIPTION
Add method to config object to remove settings by fully qualified name. This can remove single settings, but complete namespaces as well.