### PR TITLE
Add (*Config).Has

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Add (*Config).Has. #127
 
 ### Changed
 

--- a/path.go
+++ b/path.go
@@ -118,7 +118,6 @@ func (p cfgPath) Has(cfg *Config, opt *options) (bool, Error) {
 		field := fields[0]
 		next, err := field.GetValue(opt, cur)
 		if err != nil {
-
 			// has checks if a value is missing -> ErrMissing is no error but a valid
 			// outcome
 			if err.Reason() == ErrMissing {

--- a/path.go
+++ b/path.go
@@ -110,6 +110,33 @@ func (i idxField) String() string {
 	return fmt.Sprintf("%d", i.i)
 }
 
+func (p cfgPath) Has(cfg *Config, opt *options) (bool, Error) {
+	fields := p.fields
+
+	cur := value(cfgSub{cfg})
+	for ; len(fields) > 0; fields = fields[1:] {
+		field := fields[0]
+		next, err := field.GetValue(opt, cur)
+		if err != nil {
+
+			// has checks if a value is missing -> ErrMissing is no error but a valid
+			// outcome
+			if err.Reason() == ErrMissing {
+				err = nil
+			}
+			return false, err
+		}
+
+		if next == nil {
+			return false, nil
+		}
+
+		cur = next
+	}
+
+	return true, nil
+}
+
 func (p cfgPath) GetValue(cfg *Config, opt *options) (value, Error) {
 	fields := p.fields
 

--- a/ucfg.go
+++ b/ucfg.go
@@ -126,6 +126,15 @@ func (c *Config) GetFields() []string {
 	return names
 }
 
+// Has checks if a field by the given path+idx configuration exists.
+// Has returns an error if the path can not be resolved because a primitive
+// value is found in the middle of the traversal.
+func (c *Config) Has(name string, idx int, options ...Option) (bool, error) {
+	opts := makeOptions(options)
+	p := parsePathIdx(name, opts.pathSep, idx)
+	return p.Has(c, opts)
+}
+
 // HasField checks if c has a top-level named key name.
 func (c *Config) HasField(name string) bool {
 	_, ok := c.fields.get(name)

--- a/ucfg_test.go
+++ b/ucfg_test.go
@@ -364,7 +364,7 @@ func TestHas(t *testing.T) {
 			has:  false,
 			path: "a", idx: 10,
 		},
-		"intermedia is primitive": {
+		"intermediate is primitive": {
 			cfg:  map[string]interface{}{"a.b": 1},
 			fail: true,
 			path: "a.b.c", idx: -1,


### PR DESCRIPTION
Add Has method to the Config object. Has can walk a given path and reports true if there is a setting or namespace for the given path. Has returns an error if the namespace can not be walked in completion due to an intermediare not being an object/array.