### PR TITLE
Add more validation tests, fixing issue where Validate was not being called on maps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Call Validate on custom slice types. #133
+- Call Validate on custom map types. #136
 
 ## [0.7.0]
 

--- a/reify.go
+++ b/reify.go
@@ -182,6 +182,9 @@ func reifyMap(opts *options, to reflect.Value, from *Config) Error {
 
 	fields := from.fields.dict()
 	if len(fields) == 0 {
+		if err := tryValidate(to); err != nil {
+			return raiseValidation(from.ctx, from.metadata, "", err)
+		}
 		return nil
 	}
 
@@ -206,6 +209,10 @@ func reifyMap(opts *options, to reflect.Value, from *Config) Error {
 			return err
 		}
 		to.SetMapIndex(key, v)
+	}
+
+	if err := tryValidate(to); err != nil {
+		return raiseValidation(from.ctx, from.metadata, "", err)
 	}
 
 	return nil


### PR DESCRIPTION
This adds more validation tests to cover all types and structs that where not originally covered. With the added test `Validate` on `map[string]X` was not being called when defined, that is fixed in this PR.

Fixes elastic/go-ucfg#136 