### PR TITLE
Fix parsing of environment variables to prevent object parsing. #132

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Add support for HJSON. #131
+- Add new parse.Config to adjust parsing of varibles returned by a Resolve. #139
 
 ### Changed
+- Moved internal/parse to parse module. #139
+- Add parse.Config to resolvers return. #139
 
 ### Deprecated
 
@@ -16,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Call Validate on custom slice types. #133
 - Call Validate on custom map types. #136
+- Disabled object parsing of environment variables. #139
 
 ## [0.7.0]
 

--- a/flag/value.go
+++ b/flag/value.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/elastic/go-ucfg"
-	"github.com/elastic/go-ucfg/internal/parse"
+	"github.com/elastic/go-ucfg/parse"
 )
 
 // NewFlagKeyValue implements the flag.Value interface for

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -25,8 +25,33 @@ import (
 	"unicode"
 )
 
+// ParserConfig allows enabling and disabling parser features.
+type ParserConfig struct {
+	Array        bool
+	Object       bool
+	StringDQuote bool
+	StringSQuote bool
+}
+
+// DefaultParserConfig is the default config with all parser features enabled.
+var DefaultParserConfig = ParserConfig{
+	Array:        true,
+	Object:       true,
+	StringDQuote: true,
+	StringSQuote: true,
+}
+
+// EnvParserConfig is configuration for parser when the value comes from environmental variable.
+var EnvParserConfig = ParserConfig{
+	Array:        true,
+	Object:       false,
+	StringDQuote: true,
+	StringSQuote: true,
+}
+
 type flagParser struct {
 	input string
+	cfg   ParserConfig
 }
 
 // stopSet definitions for handling unquoted strings
@@ -52,7 +77,25 @@ const (
 // In addition, top-level values can be separated by ',' to build arrays
 // without having to use [].
 func Value(content string) (interface{}, error) {
-	p := &flagParser{strings.TrimSpace(content)}
+	return ValueWithConfig(content, DefaultParserConfig)
+}
+
+// ValueWithConfig parses command line arguments, supporting
+// boolean, numbers, strings, arrays, objects when enabled.
+//
+// The parser implements a superset of JSON, but only a subset of YAML by
+// allowing for arrays and objects having a trailing comma. In addition 3
+// strings types are supported:
+//
+// 1. single quoted string (no unescaping of any characters)
+// 2. double quoted strings (characters are escaped)
+// 3. strings without quotes. String parsing stops in
+//   special characters like '[]{},:'
+//
+// In addition, top-level values can be separated by ',' to build arrays
+// without having to use [].
+func ValueWithConfig(content string, cfg ParserConfig) (interface{}, error) {
+	p := &flagParser{strings.TrimSpace(content), cfg}
 	v, err := p.parse()
 	if err != nil {
 		return nil, fmt.Errorf("%v when parsing '%v'", err.Error(), content)
@@ -99,13 +142,25 @@ func (p *flagParser) parseValue(stopSet string) (interface{}, error) {
 
 	switch in[0] {
 	case '[':
-		return p.parseArray()
+		if p.cfg.Array {
+			return p.parseArray()
+		}
+		return p.parsePrimitive(stopSet)
 	case '{':
-		return p.parseObj()
+		if p.cfg.Object {
+			return p.parseObj()
+		}
+		return p.parsePrimitive(stopSet)
 	case '"':
-		return p.parseStringDQuote()
+		if p.cfg.StringDQuote {
+			return p.parseStringDQuote()
+		}
+		return p.parsePrimitive(stopSet)
 	case '\'':
-		return p.parseStringSQuote()
+		if p.cfg.StringSQuote {
+			return p.parseStringSQuote()
+		}
+		return p.parsePrimitive(stopSet)
 	default:
 		return p.parsePrimitive(stopSet)
 	}

--- a/internal/parse/parse_test.go
+++ b/internal/parse/parse_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFlagValueParsingWithDefault(t *testing.T) {
+func TestFlagValueParsingWithAll(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected interface{}
@@ -122,6 +122,7 @@ func TestFlagValueParsingWithDefault(t *testing.T) {
 	for i, test := range tests {
 		t.Logf("run test (%v): %v", i, test.input)
 
+		// `Value` has all settings enabled.
 		v, err := Value(test.input)
 		if err != nil {
 			t.Error(err)
@@ -133,7 +134,7 @@ func TestFlagValueParsingWithDefault(t *testing.T) {
 
 }
 
-func TestFlagValueParsingWithEnv(t *testing.T) {
+func TestFlagValueParsingWithNoObj(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected interface{}
@@ -215,7 +216,561 @@ func TestFlagValueParsingWithEnv(t *testing.T) {
 	for i, test := range tests {
 		t.Logf("run test (%v): %v", i, test.input)
 
+		// `EnvParserConfig` has Object disabled.
 		v, err := ValueWithConfig(test.input, EnvParserConfig)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		assert.Equal(t, test.expected, v)
+	}
+
+}
+
+func TestFlagValueParsingWithNoArrayObj(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		// null
+		{"", nil},
+		{"null", nil},
+
+		// booleans
+		{`true`, true},
+		{`false`, false},
+		{`on`, true},
+		{`off`, false},
+
+		// unsigned numbers
+		{`23`, uint64(23)},
+
+		// negative number
+		{`-42`, int64(-42)},
+
+		// floating point
+		{`3.14`, float64(3.14)},
+
+		// strings
+		{`'single quoted'`, `single quoted`},
+		{`'single quoted \"'`, `single quoted \"`},
+		{`"double quoted"`, `double quoted`},
+		{`"double quoted \""`, `double quoted "`},
+		{`plain string`, `plain string`},
+		{`string : with :: colons`, `string : with :: colons`},
+		{`C:\Windows\Style\Path`, `C:\Windows\Style\Path`},
+
+		// test arrays
+		{`[]`, "[]"},
+		{
+			`a,b,c`,
+			[]interface{}{"a", "b", "c"},
+		},
+		{
+			`C:\Windows\Path1,C:\Windows\Path2`,
+			[]interface{}{
+				`C:\Windows\Path1`,
+				`C:\Windows\Path2`,
+			},
+		},
+		{
+			`[array, 1, true, "abc",]`,
+			[]interface{}{"[array", uint64(1), true, "abc", "]"},
+		},
+		{
+			`[test, [1,2,3], on]`,
+			[]interface{}{
+				"[test",
+				"[1",
+				uint64(2),
+				"3]",
+				"on]",
+			},
+		},
+		{
+			`[host1:1234, host2:1234]`,
+			[]interface{}{
+				"[host1:1234",
+				"host2:1234]",
+			},
+		},
+
+		// test dictionaries (won't parse)
+		{`{string}`, "{string}"},
+
+		// array of top-level dictionaries
+		{
+			`{key: 1},{key: 2}`,
+			[]interface{}{
+				"{key: 1}",
+				"{key: 2}",
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("run test (%v): %v", i, test.input)
+
+		v, err := ValueWithConfig(test.input, ParserConfig{
+			Array:        false,
+			Object:       false,
+			StringDQuote: true,
+			StringSQuote: true,
+		})
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		assert.Equal(t, test.expected, v)
+	}
+
+}
+
+func TestFlagValueParsingWithNoStringDQuote(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		// null
+		{"", nil},
+		{"null", nil},
+
+		// booleans
+		{`true`, true},
+		{`false`, false},
+		{`on`, true},
+		{`off`, false},
+
+		// unsigned numbers
+		{`23`, uint64(23)},
+
+		// negative number
+		{`-42`, int64(-42)},
+
+		// floating point
+		{`3.14`, float64(3.14)},
+
+		// strings
+		{`'single quoted'`, `single quoted`},
+		{`'single quoted \"'`, `single quoted \"`},
+		{`"double quoted"`, `"double quoted"`},
+		{`"double quoted \""`, `"double quoted \""`},
+		{`plain string`, `plain string`},
+		{`string : with :: colons`, `string : with :: colons`},
+		{`C:\Windows\Style\Path`, `C:\Windows\Style\Path`},
+
+		// test arrays
+		{`[]`, nil},
+		{
+			`a,b,c`,
+			[]interface{}{"a", "b", "c"},
+		},
+		{
+			`C:\Windows\Path1,C:\Windows\Path2`,
+			[]interface{}{
+				`C:\Windows\Path1`,
+				`C:\Windows\Path2`,
+			},
+		},
+		{
+			`[array, 1, true, "abc"]`,
+			[]interface{}{"array", uint64(1), true, `"abc"`},
+		},
+		{
+			`[test, [1,2,3], on]`,
+			[]interface{}{
+				"test",
+				[]interface{}{uint64(1), uint64(2), uint64(3)},
+				true,
+			},
+		},
+		{
+			`[host1:1234, host2:1234]`,
+			[]interface{}{
+				"host1:1234",
+				"host2:1234",
+			},
+		},
+
+		// test dictionaries:
+		{`{}`, nil},
+		{`{'key1': true,
+       "key2": 1,
+       key 3: ['test', "test2", off],
+       nested key: {"a" : 2}}`,
+			map[string]interface{}{
+				"key1":  true,
+				"key2":  uint64(1),
+				"key 3": []interface{}{"test", `"test2"`, false},
+				"nested key": map[string]interface{}{
+					"a": uint64(2),
+				},
+			},
+		},
+
+		// array of top-level dictionaries
+		{
+			`{key: 1},{key: 2}`,
+			[]interface{}{
+				map[string]interface{}{
+					"key": uint64(1),
+				},
+				map[string]interface{}{
+					"key": uint64(2),
+				},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("run test (%v): %v", i, test.input)
+
+		v, err := ValueWithConfig(test.input, ParserConfig{
+			Array:        true,
+			Object:       true,
+			StringDQuote: false,
+			StringSQuote: true,
+		})
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		assert.Equal(t, test.expected, v)
+	}
+
+}
+
+func TestFlagValueParsingWithNoStringSQuote(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		// null
+		{"", nil},
+		{"null", nil},
+
+		// booleans
+		{`true`, true},
+		{`false`, false},
+		{`on`, true},
+		{`off`, false},
+
+		// unsigned numbers
+		{`23`, uint64(23)},
+
+		// negative number
+		{`-42`, int64(-42)},
+
+		// floating point
+		{`3.14`, float64(3.14)},
+
+		// strings
+		{`'single quoted'`, `'single quoted'`},
+		{`'single quoted \"'`, `'single quoted \"'`},
+		{`"double quoted"`, `double quoted`},
+		{`"double quoted \""`, `double quoted "`},
+		{`plain string`, `plain string`},
+		{`string : with :: colons`, `string : with :: colons`},
+		{`C:\Windows\Style\Path`, `C:\Windows\Style\Path`},
+
+		// test arrays
+		{`[]`, nil},
+		{
+			`a,b,c`,
+			[]interface{}{"a", "b", "c"},
+		},
+		{
+			`C:\Windows\Path1,C:\Windows\Path2`,
+			[]interface{}{
+				`C:\Windows\Path1`,
+				`C:\Windows\Path2`,
+			},
+		},
+		{
+			`[array, 1, true, "abc"]`,
+			[]interface{}{"array", uint64(1), true, "abc"},
+		},
+		{
+			`[test, [1,2,3], on]`,
+			[]interface{}{
+				"test",
+				[]interface{}{uint64(1), uint64(2), uint64(3)},
+				true,
+			},
+		},
+		{
+			`[host1:1234, host2:1234]`,
+			[]interface{}{
+				"host1:1234",
+				"host2:1234",
+			},
+		},
+
+		// test dictionaries:
+		{`{}`, nil},
+		{`{'key1': true,
+       "key2": 1,
+       key 3: ['test', "test2", off],
+       nested key: {"a" : 2}}`,
+			map[string]interface{}{
+				"key1":  true,
+				"key2":  uint64(1),
+				"key 3": []interface{}{`'test'`, "test2", false},
+				"nested key": map[string]interface{}{
+					"a": uint64(2),
+				},
+			},
+		},
+
+		// array of top-level dictionaries
+		{
+			`{key: 1},{key: 2}`,
+			[]interface{}{
+				map[string]interface{}{
+					"key": uint64(1),
+				},
+				map[string]interface{}{
+					"key": uint64(2),
+				},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("run test (%v): %v", i, test.input)
+
+		v, err := ValueWithConfig(test.input, ParserConfig{
+			Array:        true,
+			Object:       true,
+			StringDQuote: true,
+			StringSQuote: false,
+		})
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		assert.Equal(t, test.expected, v)
+	}
+
+}
+
+func TestFlagValueParsingWithNoStringDQuoteOrSQuote(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		// null
+		{"", nil},
+		{"null", nil},
+
+		// booleans
+		{`true`, true},
+		{`false`, false},
+		{`on`, true},
+		{`off`, false},
+
+		// unsigned numbers
+		{`23`, uint64(23)},
+
+		// negative number
+		{`-42`, int64(-42)},
+
+		// floating point
+		{`3.14`, float64(3.14)},
+
+		// strings
+		{`'single quoted'`, `'single quoted'`},
+		{`'single quoted \"'`, `'single quoted \"'`},
+		{`"double quoted"`, `"double quoted"`},
+		{`"double quoted \""`, `"double quoted \""`},
+		{`plain string`, `plain string`},
+		{`string : with :: colons`, `string : with :: colons`},
+		{`C:\Windows\Style\Path`, `C:\Windows\Style\Path`},
+
+		// test arrays
+		{`[]`, nil},
+		{
+			`a,b,c`,
+			[]interface{}{"a", "b", "c"},
+		},
+		{
+			`C:\Windows\Path1,C:\Windows\Path2`,
+			[]interface{}{
+				`C:\Windows\Path1`,
+				`C:\Windows\Path2`,
+			},
+		},
+		{
+			`[array, 1, true, "abc"]`,
+			[]interface{}{"array", uint64(1), true, `"abc"`},
+		},
+		{
+			`[test, [1,2,3], on]`,
+			[]interface{}{
+				"test",
+				[]interface{}{uint64(1), uint64(2), uint64(3)},
+				true,
+			},
+		},
+		{
+			`[host1:1234, host2:1234]`,
+			[]interface{}{
+				"host1:1234",
+				"host2:1234",
+			},
+		},
+
+		// test dictionaries:
+		{`{}`, nil},
+		{`{'key1': true,
+       "key2": 1,
+       key 3: ['test', "test2", off],
+       nested key: {"a" : 2}}`,
+			map[string]interface{}{
+				"key1":  true,
+				"key2":  uint64(1),
+				"key 3": []interface{}{`'test'`, `"test2"`, false},
+				"nested key": map[string]interface{}{
+					"a": uint64(2),
+				},
+			},
+		},
+
+		// array of top-level dictionaries
+		{
+			`{key: 1},{key: 2}`,
+			[]interface{}{
+				map[string]interface{}{
+					"key": uint64(1),
+				},
+				map[string]interface{}{
+					"key": uint64(2),
+				},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("run test (%v): %v", i, test.input)
+
+		v, err := ValueWithConfig(test.input, ParserConfig{
+			Array:        true,
+			Object:       true,
+			StringDQuote: false,
+			StringSQuote: false,
+		})
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		assert.Equal(t, test.expected, v)
+	}
+
+}
+
+func TestFlagValueParsingWithNoop(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		// null
+		{"", nil},
+		{"null", nil},
+
+		// booleans
+		{`true`, true},
+		{`false`, false},
+		{`on`, true},
+		{`off`, false},
+
+		// unsigned numbers
+		{`23`, uint64(23)},
+
+		// negative number
+		{`-42`, int64(-42)},
+
+		// floating point
+		{`3.14`, float64(3.14)},
+
+		// strings
+		{`'single quoted'`, `'single quoted'`},
+		{`'single quoted \"'`, `'single quoted \"'`},
+		{`"double quoted"`, `"double quoted"`},
+		{`"double quoted \""`, `"double quoted \""`},
+		{`plain string`, `plain string`},
+		{`string : with :: colons`, `string : with :: colons`},
+		{`C:\Windows\Style\Path`, `C:\Windows\Style\Path`},
+
+		// test arrays
+		{`[]`, `[]`},
+		{
+			`a,b,c`,
+			[]interface{}{"a", "b", "c"},
+		},
+		{
+			`C:\Windows\Path1,C:\Windows\Path2`,
+			[]interface{}{
+				`C:\Windows\Path1`,
+				`C:\Windows\Path2`,
+			},
+		},
+		{
+			`[array, 1, true, "abc"]`,
+			[]interface{}{"[array", uint64(1), true, `"abc"]`},
+		},
+		{
+			`[test, [1,2,3], on]`,
+			[]interface{}{
+				"[test",
+				"[1",
+				uint64(2),
+				"3]",
+				"on]",
+			},
+		},
+		{
+			`[host1:1234, host2:1234]`,
+			[]interface{}{
+				"[host1:1234",
+				"host2:1234]",
+			},
+		},
+
+		// test dictionaries:
+		{`{}`, `{}`},
+		{`{'key1': true,
+       "key2": 1,
+       key 3: ['test', "test2", off],
+	   nested key: {"a" : 2}}`,
+			[]interface{}{
+				`{'key1': true`,
+				`"key2": 1`,
+				`key 3: ['test'`,
+				`"test2"`,
+				`off]`,
+				`nested key: {"a" : 2}}`,
+			},
+		},
+
+		// array of top-level dictionaries
+		{
+			`{key: 1},{key: 2}`,
+			[]interface{}{
+				"{key: 1}",
+				"{key: 2}",
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("run test (%v): %v", i, test.input)
+
+		v, err := ValueWithConfig(test.input, NoopParserConfig)
 		if err != nil {
 			t.Error(err)
 			continue

--- a/internal/parse/parse_test.go
+++ b/internal/parse/parse_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFlagValueParsing(t *testing.T) {
+func TestFlagValueParsingWithDefault(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected interface{}
@@ -123,6 +123,99 @@ func TestFlagValueParsing(t *testing.T) {
 		t.Logf("run test (%v): %v", i, test.input)
 
 		v, err := Value(test.input)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		assert.Equal(t, test.expected, v)
+	}
+
+}
+
+func TestFlagValueParsingWithEnv(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		// null
+		{"", nil},
+		{"null", nil},
+
+		// booleans
+		{`true`, true},
+		{`false`, false},
+		{`on`, true},
+		{`off`, false},
+
+		// unsigned numbers
+		{`23`, uint64(23)},
+
+		// negative number
+		{`-42`, int64(-42)},
+
+		// floating point
+		{`3.14`, float64(3.14)},
+
+		// strings
+		{`'single quoted'`, `single quoted`},
+		{`'single quoted \"'`, `single quoted \"`},
+		{`"double quoted"`, `double quoted`},
+		{`"double quoted \""`, `double quoted "`},
+		{`plain string`, `plain string`},
+		{`string : with :: colons`, `string : with :: colons`},
+		{`C:\Windows\Style\Path`, `C:\Windows\Style\Path`},
+
+		// test arrays
+		{`[]`, nil},
+		{
+			`a,b,c`,
+			[]interface{}{"a", "b", "c"},
+		},
+		{
+			`C:\Windows\Path1,C:\Windows\Path2`,
+			[]interface{}{
+				`C:\Windows\Path1`,
+				`C:\Windows\Path2`,
+			},
+		},
+		{
+			`[array, 1, true, "abc"]`,
+			[]interface{}{"array", uint64(1), true, "abc"},
+		},
+		{
+			`[test, [1,2,3], on]`,
+			[]interface{}{
+				"test",
+				[]interface{}{uint64(1), uint64(2), uint64(3)},
+				true,
+			},
+		},
+		{
+			`[host1:1234, host2:1234]`,
+			[]interface{}{
+				"host1:1234",
+				"host2:1234",
+			},
+		},
+
+		// test dictionaries (won't parse)
+		{`{string}`, "{string}"},
+
+		// array of top-level dictionaries
+		{
+			`{key: 1},{key: 2}`,
+			[]interface{}{
+				"{key: 1}",
+				"{key: 2}",
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("run test (%v): %v", i, test.input)
+
+		v, err := ValueWithConfig(test.input, EnvParserConfig)
 		if err != nil {
 			t.Error(err)
 			continue

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -25,32 +25,32 @@ import (
 	"unicode"
 )
 
-// ParserConfig allows enabling and disabling parser features.
-type ParserConfig struct {
+// Config allows enabling and disabling parser features.
+type Config struct {
 	Array        bool
 	Object       bool
 	StringDQuote bool
 	StringSQuote bool
 }
 
-// DefaultParserConfig is the default config with all parser features enabled.
-var DefaultParserConfig = ParserConfig{
+// DefaultConfig is the default config with all parser features enabled.
+var DefaultConfig = Config{
 	Array:        true,
 	Object:       true,
 	StringDQuote: true,
 	StringSQuote: true,
 }
 
-// EnvParserConfig is configuration for parser when the value comes from environmental variable.
-var EnvParserConfig = ParserConfig{
+// EnvConfig is configuration for parser when the value comes from environmental variable.
+var EnvConfig = Config{
 	Array:        true,
 	Object:       false,
 	StringDQuote: true,
 	StringSQuote: true,
 }
 
-// NoopParserConfig is configuration for parser that disables all options.
-var NoopParserConfig = ParserConfig{
+// NoopConfig is configuration for parser that disables all options.
+var NoopConfig = Config{
 	Array:        false,
 	Object:       false,
 	StringDQuote: false,
@@ -59,7 +59,7 @@ var NoopParserConfig = ParserConfig{
 
 type flagParser struct {
 	input string
-	cfg   ParserConfig
+	cfg   Config
 }
 
 // stopSet definitions for handling unquoted strings
@@ -85,7 +85,7 @@ const (
 // In addition, top-level values can be separated by ',' to build arrays
 // without having to use [].
 func Value(content string) (interface{}, error) {
-	return ValueWithConfig(content, DefaultParserConfig)
+	return ValueWithConfig(content, DefaultConfig)
 }
 
 // ValueWithConfig parses command line arguments, supporting
@@ -102,7 +102,7 @@ func Value(content string) (interface{}, error) {
 //
 // In addition, top-level values can be separated by ',' to build arrays
 // without having to use [].
-func ValueWithConfig(content string, cfg ParserConfig) (interface{}, error) {
+func ValueWithConfig(content string, cfg Config) (interface{}, error) {
 	p := &flagParser{strings.TrimSpace(content), cfg}
 	if err := p.validateConfig(); err != nil {
 		return nil, err

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -216,8 +216,8 @@ func TestFlagValueParsingWithNoObj(t *testing.T) {
 	for i, test := range tests {
 		t.Logf("run test (%v): %v", i, test.input)
 
-		// `EnvParserConfig` has Object disabled.
-		v, err := ValueWithConfig(test.input, EnvParserConfig)
+		// `EnvConfig` has Object disabled.
+		v, err := ValueWithConfig(test.input, EnvConfig)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -312,7 +312,7 @@ func TestFlagValueParsingWithNoArrayObj(t *testing.T) {
 	for i, test := range tests {
 		t.Logf("run test (%v): %v", i, test.input)
 
-		v, err := ValueWithConfig(test.input, ParserConfig{
+		v, err := ValueWithConfig(test.input, Config{
 			Array:        false,
 			Object:       false,
 			StringDQuote: true,
@@ -427,7 +427,7 @@ func TestFlagValueParsingWithNoStringDQuote(t *testing.T) {
 	for i, test := range tests {
 		t.Logf("run test (%v): %v", i, test.input)
 
-		v, err := ValueWithConfig(test.input, ParserConfig{
+		v, err := ValueWithConfig(test.input, Config{
 			Array:        true,
 			Object:       true,
 			StringDQuote: false,
@@ -542,7 +542,7 @@ func TestFlagValueParsingWithNoStringSQuote(t *testing.T) {
 	for i, test := range tests {
 		t.Logf("run test (%v): %v", i, test.input)
 
-		v, err := ValueWithConfig(test.input, ParserConfig{
+		v, err := ValueWithConfig(test.input, Config{
 			Array:        true,
 			Object:       true,
 			StringDQuote: true,
@@ -657,7 +657,7 @@ func TestFlagValueParsingWithNoStringDQuoteOrSQuote(t *testing.T) {
 	for i, test := range tests {
 		t.Logf("run test (%v): %v", i, test.input)
 
-		v, err := ValueWithConfig(test.input, ParserConfig{
+		v, err := ValueWithConfig(test.input, Config{
 			Array:        true,
 			Object:       true,
 			StringDQuote: false,
@@ -770,7 +770,7 @@ func TestFlagValueParsingWithNoop(t *testing.T) {
 	for i, test := range tests {
 		t.Logf("run test (%v): %v", i, test.input)
 
-		v, err := ValueWithConfig(test.input, NoopParserConfig)
+		v, err := ValueWithConfig(test.input, NoopConfig)
 		if err != nil {
 			t.Error(err)
 			continue

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -23,6 +23,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestParseWithObjectButNoArrayErrors(t *testing.T) {
+	_, err := ValueWithConfig("", Config{
+		Array:        false,
+		Object:       true,
+		StringDQuote: true,
+		StringSQuote: true,
+	})
+	if err == nil {
+		t.Error("should have failed")
+	}
+}
+
 func TestFlagValueParsingWithAll(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/reify_test.go
+++ b/reify_test.go
@@ -115,6 +115,7 @@ func TestUnpackPrimitivesValuesResolve(t *testing.T) {
 			U uint
 			F float64
 			S string
+			W string
 		}{},
 		&struct {
 			B interface{}
@@ -122,6 +123,7 @@ func TestUnpackPrimitivesValuesResolve(t *testing.T) {
 			U interface{}
 			F interface{}
 			S interface{}
+			W interface{}
 		}{},
 		&struct {
 			B *bool
@@ -129,6 +131,7 @@ func TestUnpackPrimitivesValuesResolve(t *testing.T) {
 			U *uint
 			F *float64
 			S *string
+			W *string
 		}{},
 	}
 
@@ -141,6 +144,7 @@ func TestUnpackPrimitivesValuesResolve(t *testing.T) {
 				"v_u": "23",
 				"v_f": "3.14",
 				"v_s": "string",
+				"v_w": "{string}",
 			}[name], nil
 		}),
 	}
@@ -151,6 +155,7 @@ func TestUnpackPrimitivesValuesResolve(t *testing.T) {
 		"u": "${v_u}",
 		"f": "${v_f}",
 		"s": "${v_s}",
+		"w": "${v_w}",
 	}, cfgOpts...)
 
 	for i, out := range tests {
@@ -186,11 +191,15 @@ func TestUnpackPrimitivesValuesResolve(t *testing.T) {
 		s, err := c.String("s", -1, cfgOpts...)
 		assert.NoError(t, err)
 
+		w, err := c.String("w", -1, cfgOpts...)
+		assert.NoError(t, err)
+
 		assert.Equal(t, true, b)
 		assert.Equal(t, 42, int(i))
 		assert.Equal(t, 23, int(u))
 		assert.Equal(t, 3.14, f)
 		assert.Equal(t, "string", s)
+		assert.Equal(t, "{string}", w)
 	}
 }
 

--- a/reify_test.go
+++ b/reify_test.go
@@ -20,6 +20,7 @@ package ucfg
 import (
 	"testing"
 
+	"github.com/elastic/go-ucfg/parse"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -137,7 +138,7 @@ func TestUnpackPrimitivesValuesResolve(t *testing.T) {
 
 	cfgOpts := []Option{
 		VarExp,
-		Resolve(func(name string) (string, error) {
+		Resolve(func(name string) (string, parse.Config, error) {
 			return map[string]string{
 				"v_b": "true",
 				"v_i": "42",
@@ -145,7 +146,7 @@ func TestUnpackPrimitivesValuesResolve(t *testing.T) {
 				"v_f": "3.14",
 				"v_s": "string",
 				"v_w": "{string}",
-			}[name], nil
+			}[name], parse.EnvConfig, nil
 		}),
 	}
 

--- a/structs_test.go
+++ b/structs_test.go
@@ -67,7 +67,6 @@ func TestStructMergeUnpackTyped(t *testing.T) {
 			},
 			env: testEnv{"env_strings": "one"},
 		},
-
 		{
 			t: &struct {
 				Hosts []string
@@ -78,6 +77,17 @@ func TestStructMergeUnpackTyped(t *testing.T) {
 				"hosts": "${hosts_from_env}",
 			},
 			env: testEnv{"hosts_from_env": "host1:1234,host2:4567"},
+		},
+		{
+			t: &struct {
+				Hosts []string
+			}{
+				Hosts: []string{"{host1}:1234", "host2:4567"},
+			},
+			cfg: map[string]interface{}{
+				"hosts": "${hosts_from_env}",
+			},
+			env: testEnv{"hosts_from_env": "{host1}:1234,host2:4567"},
 		},
 		{
 			t: &struct {

--- a/structs_test.go
+++ b/structs_test.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/elastic/go-ucfg/parse"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -217,16 +218,16 @@ func TestIgnoreStructFields(t *testing.T) {
 }
 
 func resolveTestEnv(e testEnv) Option {
-	fail := func(name string) (string, error) {
-		return "", fmt.Errorf("empty environment variable %v", name)
+	fail := func(name string) (string, parse.Config, error) {
+		return "", parse.EnvConfig, fmt.Errorf("empty environment variable %v", name)
 	}
 
 	if e == nil {
 		return Resolve(fail)
 	}
-	return Resolve(func(name string) (string, error) {
+	return Resolve(func(name string) (string, parse.Config, error) {
 		if v := e[name]; v != "" {
-			return v, nil
+			return v, parse.EnvConfig, nil
 		}
 		return fail(name)
 	})

--- a/types.go
+++ b/types.go
@@ -533,7 +533,7 @@ func (r *refDynValue) getValue(
 		}
 		return nil, err
 	}
-	return parseValue(p, opts, str)
+	return parseValue(p, opts, str, parse.EnvParserConfig)
 }
 
 func (s spliceDynValue) getValue(
@@ -546,19 +546,19 @@ func (s spliceDynValue) getValue(
 		return nil, err
 	}
 
-	return parseValue(p, opts, str)
+	return parseValue(p, opts, str, parse.DefaultParserConfig)
 }
 
 func (s spliceDynValue) String() string {
 	return "<splice>"
 }
 
-func parseValue(p *cfgPrimitive, opts *options, str string) (value, error) {
+func parseValue(p *cfgPrimitive, opts *options, str string, parserCfg parse.ParserConfig) (value, error) {
 	if opts.noParse {
 		return nil, raiseNoParse(p.ctx, p.meta())
 	}
 
-	ifc, err := parse.Value(str)
+	ifc, err := parse.ValueWithConfig(str, parserCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/types.go
+++ b/types.go
@@ -26,7 +26,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/elastic/go-ucfg/internal/parse"
+	"github.com/elastic/go-ucfg/parse"
 )
 
 type value interface {
@@ -523,7 +523,7 @@ func (r *refDynValue) getValue(
 	}
 	previousErr := err
 
-	str, err := ref.resolveEnv(p.ctx.getParent(), opts)
+	str, parseCfg, err := ref.resolveEnv(p.ctx.getParent(), opts)
 	if err != nil {
 		// TODO(ph): Not everything is an Error, will do some cleanup in another PR.
 		if v, ok := previousErr.(Error); ok {
@@ -533,7 +533,7 @@ func (r *refDynValue) getValue(
 		}
 		return nil, err
 	}
-	return parseValue(p, opts, str, parse.EnvParserConfig)
+	return parseValue(p, opts, str, parseCfg)
 }
 
 func (s spliceDynValue) getValue(
@@ -546,19 +546,19 @@ func (s spliceDynValue) getValue(
 		return nil, err
 	}
 
-	return parseValue(p, opts, str, parse.DefaultParserConfig)
+	return parseValue(p, opts, str, parse.DefaultConfig)
 }
 
 func (s spliceDynValue) String() string {
 	return "<splice>"
 }
 
-func parseValue(p *cfgPrimitive, opts *options, str string, parserCfg parse.ParserConfig) (value, error) {
+func parseValue(p *cfgPrimitive, opts *options, str string, parseCfg parse.Config) (value, error) {
 	if opts.noParse {
 		return nil, raiseNoParse(p.ctx, p.meta())
 	}
 
-	ifc, err := parse.ValueWithConfig(str, parserCfg)
+	ifc, err := parse.ValueWithConfig(str, parseCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/ucfg_test.go
+++ b/ucfg_test.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/elastic/go-ucfg/parse"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -190,11 +191,11 @@ func TestCyclicReferenceShouldFallbackToOtherResolvers(t *testing.T) {
 		"top.reference": "${top.reference}",
 	}
 
-	resolveFn := func(key string) (string, error) {
+	resolveFn := func(key string) (string, parse.Config, error) {
 		if key == "top.reference" {
-			return "reference-found", nil
+			return "reference-found", parse.DefaultConfig, nil
 		}
-		return "", ErrMissing
+		return "", parse.DefaultConfig, ErrMissing
 	}
 
 	opts := []Option{
@@ -212,11 +213,11 @@ func TestCyclicReferenceShouldFallbackToOtherResolvers(t *testing.T) {
 }
 
 func TestTopYamlKeyInEnvResolvers(t *testing.T) {
-	resolveFn := func(key string) (string, error) {
+	resolveFn := func(key string) (string, parse.Config, error) {
 		if key == "a.key" {
-			return "key-found", nil
+			return "key-found", parse.DefaultConfig, nil
 		}
-		return "", fmt.Errorf("could not find the key: %s", key)
+		return "", parse.DefaultConfig, fmt.Errorf("could not find the key: %s", key)
 	}
 
 	opts := []Option{


### PR DESCRIPTION
Currently `internal/parse` handles the values from the environment variable just like values from the configuration file. This PR changes the parser to limit environment variable parsing to not parse object notation.

This is a **breaking** change because if any environment relies on this behavior it would break them. I question if this is correct way to solve the bug.

Really the bug could be solved by ensuring that the environment variable is single quoted:

```
export ENV_VAR="'{user}'"
```

I would be okay with closing this PR and closing the bug with this comment.