### PR TITLE
Add call to InitDefaults when structs implement Initializer interface during Unpack.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Add support for HJSON. #131
 - Add new parse.Config to adjust parsing of varibles returned by a Resolve. #139
-- Add call to InitDefaults when structs implement Initializer interface during Unpack. #104
+- Add call to InitDefaults when map, primitives, or structs implement Initializer interface during Unpack. #104
 
 ### Changed
 - Moved internal/parse to parse module. #139

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Add support for HJSON. #131
 - Add new parse.Config to adjust parsing of varibles returned by a Resolve. #139
+- Add call to InitDefaults when structs implement Initializer interface during Unpack. #104
 
 ### Changed
 - Moved internal/parse to parse module. #139

--- a/initializer.go
+++ b/initializer.go
@@ -40,6 +40,9 @@ func tryInitDefaults(val reflect.Value) reflect.Value {
 		tmp := pointerize(reflect.PtrTo(t), t, val)
 		initializer = tmp.Interface().(Initializer)
 		initializer.InitDefaults()
+
+		// Return the element in the pointer so the value is set into the
+		// field and not a pointer to the value.
 		return tmp.Elem()
 	}
 	return val

--- a/initializer.go
+++ b/initializer.go
@@ -30,16 +30,25 @@ type Initializer interface {
 
 func tryInitDefaults(val reflect.Value) {
 	t := val.Type()
-	var initializer Initializer
 
+	var initializer Initializer
 	if t.Implements(iInitializer) {
 		initializer = val.Interface().(Initializer)
 	} else if reflect.PtrTo(t).Implements(iInitializer) {
 		val = pointerize(reflect.PtrTo(t), t, val)
 		initializer = val.Interface().(Initializer)
 	}
-
 	if initializer != nil {
 		initializer.InitDefaults()
 	}
+}
+
+func hasInitDefaults(t reflect.Type) bool {
+	if t.Implements(iInitializer) {
+		return true
+	}
+	if reflect.PtrTo(t).Implements(iInitializer) {
+		return true
+	}
+	return false
 }

--- a/initializer.go
+++ b/initializer.go
@@ -1,0 +1,45 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ucfg
+
+import (
+	"reflect"
+)
+
+// Initializer interface provides initialization of default values support to Unpack.
+// The InitDefaults method will be executed for any type passed directly or indirectly to
+// Unpack.
+type Initializer interface {
+	InitDefaults()
+}
+
+func tryInitDefaults(val reflect.Value) {
+	t := val.Type()
+	var initializer Initializer
+
+	if t.Implements(iInitializer) {
+		initializer = val.Interface().(Initializer)
+	} else if reflect.PtrTo(t).Implements(iInitializer) {
+		val = pointerize(reflect.PtrTo(t), t, val)
+		initializer = val.Interface().(Initializer)
+	}
+
+	if initializer != nil {
+		initializer.InitDefaults()
+	}
+}

--- a/initializer.go
+++ b/initializer.go
@@ -28,19 +28,21 @@ type Initializer interface {
 	InitDefaults()
 }
 
-func tryInitDefaults(val reflect.Value) {
+func tryInitDefaults(val reflect.Value) reflect.Value {
 	t := val.Type()
 
 	var initializer Initializer
 	if t.Implements(iInitializer) {
 		initializer = val.Interface().(Initializer)
-	} else if reflect.PtrTo(t).Implements(iInitializer) {
-		val = pointerize(reflect.PtrTo(t), t, val)
-		initializer = val.Interface().(Initializer)
-	}
-	if initializer != nil {
 		initializer.InitDefaults()
+		return val
+	} else if reflect.PtrTo(t).Implements(iInitializer) {
+		tmp := pointerize(reflect.PtrTo(t), t, val)
+		initializer = tmp.Interface().(Initializer)
+		initializer.InitDefaults()
+		return tmp.Elem()
 	}
+	return val
 }
 
 func hasInitDefaults(t reflect.Type) bool {

--- a/initializer_test.go
+++ b/initializer_test.go
@@ -228,11 +228,8 @@ func TestInitDefaultsPtrNestedEmpty(t *testing.T) {
 
 	err := c.Unpack(r)
 	assert.NoError(t, err)
-	assert.Equal(t, myMapInitializer{
-		"init": "defaults",
-	}, *r.S.M)
-	assert.Equal(t, 0, r.S.N.I)
-	assert.Equal(t, 10, r.S.N.J)
+	assert.Nil(t, r.S.M)
+	assert.Nil(t, r.S.N)
+	assert.Nil(t, r.S.P)
 	assert.Equal(t, 20, r.S.O)
-	assert.Equal(t, myIntInitializer(3), r.S.P.I)
 }

--- a/initializer_test.go
+++ b/initializer_test.go
@@ -1,0 +1,84 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ucfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type structInitializer struct {
+	I int
+	J int
+}
+
+func (s *structInitializer) InitDefaults() {
+	s.J = 10
+}
+
+type nestedStructInitializer struct {
+	N structInitializer
+	O int
+}
+
+func (n *nestedStructInitializer) InitDefaults() {
+	n.O = 20
+
+	// overridden by InitDefaults from structInitializer
+	n.N.J = 15
+}
+
+func TestInitDefaultsSingle(t *testing.T) {
+	c, _ := NewFrom(map[string]interface{}{
+		"s": map[string]interface{}{
+			"i": 5,
+		},
+	})
+
+	// unpack S
+	r := &struct {
+		S structInitializer
+	}{}
+
+	err := c.Unpack(r)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, r.S.I)
+	assert.Equal(t, 10, r.S.J)
+}
+
+func TestInitDefaultsNested(t *testing.T) {
+	c, _ := NewFrom(map[string]interface{}{
+		"s": map[string]interface{}{
+			"n": map[string]interface{}{
+				"i": 5,
+			},
+		},
+	})
+
+	// unpack S
+	r := &struct {
+		S nestedStructInitializer
+	}{}
+
+	err := c.Unpack(r)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, r.S.N.I)
+	assert.Equal(t, 10, r.S.N.J)
+	assert.Equal(t, 20, r.S.O)
+}

--- a/reify.go
+++ b/reify.go
@@ -232,7 +232,7 @@ func reifyStruct(opts *options, orig reflect.Value, cfg *Config) Error {
 	}
 
 	if v, ok := valueIsUnpacker(to); ok {
-		err := unpackWith(opts, v, cfgSub{cfg})
+		err := unpackWith(opts, v, cfgSubFlex{cfgSub{cfg}})
 		if err != nil {
 			return err
 		}

--- a/reify.go
+++ b/reify.go
@@ -298,9 +298,6 @@ func reifyStruct(opts *options, orig reflect.Value, cfg *Config) Error {
 				}
 			} else {
 				name = fieldName(name, stField.Name)
-				if name == "i" {
-					name = "i"
-				}
 				fopts := fieldOptions{opts: opts, tag: tagOpts, validators: validators}
 				if err := reifyGetField(cfg, fopts, name, vField, stField.Type); err != nil {
 					return err

--- a/reify.go
+++ b/reify.go
@@ -85,8 +85,12 @@ import (
 //  The struct tag options `replace`, `append`, and `prepend` overwrites the
 //  global value merging strategy (e.g. ReplaceValues, AppendValues, ...) for all sub-fields.
 //
+// When unpacking into a map, primitive, or struct Unpack will call InitDefaults if
+// the type implements the Initializer interface. The Initializer interface is not supported
+// on arrays or slices.
+//
 // Fields available in a struct or a map, but not in the Config object, will not
-// be touched. Default values should be set in the target value before calling Unpack.
+// be touched by Unpack unless they are initialized from InitDefaults.
 //
 // Type aliases like "type myTypeAlias T" are unpacked using Unpack if the alias
 // implements the Unpacker interface. Otherwise unpacking rules for type T will be used.

--- a/reify.go
+++ b/reify.go
@@ -91,7 +91,10 @@ import (
 // a map, struct, or primitive that also implements the Initializer interface the contained
 // type will be initialized after the struct that contains it. (e.g. if we have
 // type A struct { B B }, with both A, and B implementing InitDefaults, then A.InitDefaults
-// is called before B.InitDefaults).
+// is called before B.InitDefaults). In the case that a struct contains a pointer to
+// a type that implements the Initializer interface and the configuration doesn't contain a
+// value for that field then the pointer will not be initialized and InitDefaults will not
+// be called.
 //
 // Fields available in a struct or a map, but not in the Config object, will not
 // be touched by Unpack unless they are initialized from InitDefaults.

--- a/reify.go
+++ b/reify.go
@@ -229,6 +229,9 @@ func reifyStruct(opts *options, orig reflect.Value, cfg *Config) Error {
 		to.Set(orig)
 	}
 
+	// Execute InitDefaults on the structure when defined.
+	tryInitDefaults(to)
+
 	if v, ok := valueIsUnpacker(to); ok {
 		err := unpackWith(opts, v, cfgSub{cfg})
 		if err != nil {

--- a/types.go
+++ b/types.go
@@ -94,6 +94,7 @@ type cfgSub struct {
 }
 
 type cfgNil struct{ cfgPrimitive }
+type cfgEmpty struct{ cfgPrimitive }
 
 type cfgPrimitive struct {
 	ctx      context
@@ -221,6 +222,29 @@ func (c *cfgNil) reflect(opts *options) (reflect.Value, error) {
 }
 
 func (c *cfgNil) toConfig(*options) (*Config, error) {
+	n := New()
+	n.ctx = c.ctx
+	return n, nil
+}
+
+func (c *cfgEmpty) cpy(ctx context) value             { return &cfgEmpty{cfgPrimitive{ctx, c.metadata}} }
+func (*cfgEmpty) Len(*options) (int, error)           { return 0, ErrEmpty }
+func (*cfgEmpty) toBool(*options) (bool, error)       { return false, ErrEmpty }
+func (*cfgEmpty) toString(*options) (string, error)   { return "", ErrEmpty }
+func (*cfgEmpty) toInt(*options) (int64, error)       { return 0, ErrEmpty }
+func (*cfgEmpty) toUint(*options) (uint64, error)     { return 0, ErrEmpty }
+func (*cfgEmpty) toFloat(*options) (float64, error)   { return 0, ErrEmpty }
+func (*cfgEmpty) reify(*options) (interface{}, error) { return nil, nil }
+func (*cfgEmpty) typ(*options) (typeInfo, error)      { return typeInfo{"any", reflect.PtrTo(tConfig)}, nil }
+func (c *cfgEmpty) meta() *Meta                       { return c.metadata }
+func (c *cfgEmpty) setMeta(m *Meta)                   { c.metadata = m }
+
+func (c *cfgEmpty) reflect(opts *options) (reflect.Value, error) {
+	cfg, _ := c.toConfig(opts)
+	return reflect.ValueOf(cfg), nil
+}
+
+func (c *cfgEmpty) toConfig(*options) (*Config, error) {
 	n := New()
 	n.ctx = c.ctx
 	return n, nil
@@ -597,6 +621,14 @@ func isNil(v value) bool {
 		return true
 	}
 	_, tst := v.(*cfgNil)
+	return tst
+}
+
+func isEmpty(v value) bool {
+	if v == nil {
+		return true
+	}
+	_, tst := v.(*cfgEmpty)
 	return tst
 }
 

--- a/types.go
+++ b/types.go
@@ -89,6 +89,8 @@ type cfgString struct {
 	s string
 }
 
+type cfgSubFlex struct{ cfgSub }
+
 type cfgSub struct {
 	c *Config
 }
@@ -438,6 +440,12 @@ func (c cfgSub) reify(opts *options) (interface{}, error) {
 		return m, nil
 	}
 }
+
+func (cfgSubFlex) toBool(*options) (bool, error)     { return false, nil }
+func (cfgSubFlex) toString(*options) (string, error) { return "", nil }
+func (cfgSubFlex) toInt(*options) (int64, error)     { return 0, nil }
+func (cfgSubFlex) toUint(*options) (uint64, error)   { return 0, nil }
+func (cfgSubFlex) toFloat(*options) (float64, error) { return 0, nil }
 
 func (d *cfgDynamic) typ(opts *options) (ti typeInfo, err error) {
 	d.withValue(&err, opts, func(v value) {

--- a/types.go
+++ b/types.go
@@ -89,14 +89,11 @@ type cfgString struct {
 	s string
 }
 
-type cfgSubFlex struct{ cfgSub }
-
 type cfgSub struct {
 	c *Config
 }
 
 type cfgNil struct{ cfgPrimitive }
-type cfgEmpty struct{ cfgPrimitive }
 
 type cfgPrimitive struct {
 	ctx      context
@@ -224,29 +221,6 @@ func (c *cfgNil) reflect(opts *options) (reflect.Value, error) {
 }
 
 func (c *cfgNil) toConfig(*options) (*Config, error) {
-	n := New()
-	n.ctx = c.ctx
-	return n, nil
-}
-
-func (c *cfgEmpty) cpy(ctx context) value             { return &cfgEmpty{cfgPrimitive{ctx, c.metadata}} }
-func (*cfgEmpty) Len(*options) (int, error)           { return 0, ErrEmpty }
-func (*cfgEmpty) toBool(*options) (bool, error)       { return false, ErrEmpty }
-func (*cfgEmpty) toString(*options) (string, error)   { return "", ErrEmpty }
-func (*cfgEmpty) toInt(*options) (int64, error)       { return 0, ErrEmpty }
-func (*cfgEmpty) toUint(*options) (uint64, error)     { return 0, ErrEmpty }
-func (*cfgEmpty) toFloat(*options) (float64, error)   { return 0, ErrEmpty }
-func (*cfgEmpty) reify(*options) (interface{}, error) { return nil, nil }
-func (*cfgEmpty) typ(*options) (typeInfo, error)      { return typeInfo{"any", reflect.PtrTo(tConfig)}, nil }
-func (c *cfgEmpty) meta() *Meta                       { return c.metadata }
-func (c *cfgEmpty) setMeta(m *Meta)                   { c.metadata = m }
-
-func (c *cfgEmpty) reflect(opts *options) (reflect.Value, error) {
-	cfg, _ := c.toConfig(opts)
-	return reflect.ValueOf(cfg), nil
-}
-
-func (c *cfgEmpty) toConfig(*options) (*Config, error) {
 	n := New()
 	n.ctx = c.ctx
 	return n, nil
@@ -441,12 +415,6 @@ func (c cfgSub) reify(opts *options) (interface{}, error) {
 	}
 }
 
-func (cfgSubFlex) toBool(*options) (bool, error)     { return false, nil }
-func (cfgSubFlex) toString(*options) (string, error) { return "", nil }
-func (cfgSubFlex) toInt(*options) (int64, error)     { return 0, nil }
-func (cfgSubFlex) toUint(*options) (uint64, error)   { return 0, nil }
-func (cfgSubFlex) toFloat(*options) (float64, error) { return 0, nil }
-
 func (d *cfgDynamic) typ(opts *options) (ti typeInfo, err error) {
 	d.withValue(&err, opts, func(v value) {
 		ti, err = v.typ(opts)
@@ -629,14 +597,6 @@ func isNil(v value) bool {
 		return true
 	}
 	_, tst := v.(*cfgNil)
-	return tst
-}
-
-func isEmpty(v value) bool {
-	if v == nil {
-		return true
-	}
-	_, tst := v.(*cfgEmpty)
 	return tst
 }
 

--- a/ucfg.go
+++ b/ucfg.go
@@ -63,8 +63,9 @@ var (
 	tInterfaceArray = reflect.TypeOf([]interface{}(nil))
 
 	// interface types
-	tError     = reflect.TypeOf((*error)(nil)).Elem()
-	tValidator = reflect.TypeOf((*Validator)(nil)).Elem()
+	tError       = reflect.TypeOf((*error)(nil)).Elem()
+	iInitializer = reflect.TypeOf((*Initializer)(nil)).Elem()
+	tValidator   = reflect.TypeOf((*Validator)(nil)).Elem()
 
 	// primitives
 	tBool     = reflect.TypeOf(true)

--- a/ucfg_test.go
+++ b/ucfg_test.go
@@ -400,7 +400,7 @@ func TestRemove(t *testing.T) {
 	}{
 		"exist": {
 			cfg:   map[string]interface{}{"field": "test"},
-			wants: nil,
+			wants: map[string]interface{}{},
 			spec:  spec{has: true, path: "field", idx: -1},
 		},
 		"unknown field": {

--- a/unpack.go
+++ b/unpack.go
@@ -159,6 +159,11 @@ func implementsUnpacker(t reflect.Type) bool {
 }
 
 func unpackWith(opts *options, v reflect.Value, with value) Error {
+	// short circuit nil values
+	if isNil(with) {
+		return nil
+	}
+
 	ctx := with.Context()
 	meta := with.meta()
 
@@ -215,7 +220,7 @@ func unpackWith(opts *options, v reflect.Value, with value) Error {
 
 	}
 
-	if err != nil && err != ErrEmpty {
+	if err != nil {
 		return raisePathErr(err, meta, "", ctx.path("."))
 	}
 	return nil

--- a/unpack.go
+++ b/unpack.go
@@ -215,7 +215,7 @@ func unpackWith(opts *options, v reflect.Value, with value) Error {
 
 	}
 
-	if err != nil {
+	if err != nil && err != ErrEmpty {
 		return raisePathErr(err, meta, "", ctx.path("."))
 	}
 	return nil

--- a/unpack_test.go
+++ b/unpack_test.go
@@ -146,7 +146,9 @@ func TestReifyUnpackers(t *testing.T) {
 	}
 
 	// apply configurations
-	for _, c := range configs {
+	for i, c := range configs {
+		t.Logf("Test config (%v): %#v", i, c)
+
 		cfg, err := NewFrom(c)
 		if err != nil {
 			t.Fatal(err)
@@ -204,7 +206,9 @@ func TestReifyUnpackersPtr(t *testing.T) {
 	}
 
 	// apply configurations
-	for _, c := range configs {
+	for i, c := range configs {
+		t.Logf("Test config (%v): %#v", i, c)
+
 		cfg, err := NewFrom(c)
 		if err != nil {
 			t.Fatal(err)

--- a/unpack_test.go
+++ b/unpack_test.go
@@ -147,7 +147,7 @@ func TestReifyUnpackers(t *testing.T) {
 
 	// apply configurations
 	for i, c := range configs {
-		t.Logf("Test config (%v): %#v", i, c)
+		t.Logf("Unpacking config (%v): %#v", i, c)
 
 		cfg, err := NewFrom(c)
 		if err != nil {
@@ -207,7 +207,7 @@ func TestReifyUnpackersPtr(t *testing.T) {
 
 	// apply configurations
 	for i, c := range configs {
-		t.Logf("Test config (%v): %#v", i, c)
+		t.Logf("Unpacking config (%v): %#v", i, c)
 
 		cfg, err := NewFrom(c)
 		if err != nil {


### PR DESCRIPTION
Call the `InitDefaults` during `Unpack` when a structure implements the `Initializer` interface. This allows a structure to define its default values without having to push the defaults into the loaded configuration.

Closes #104 