### PR TITLE
Apply validation to default values even when values do not come from the configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Call Validate on custom slice types. #133
 - Call Validate on custom map types. #136
 - Disabled object parsing of environment variables. #139
+- Apply validation to defaults passed into Unpack when Config doesn't contain a value. #42
 
 ## [0.7.0]
 

--- a/reify_test.go
+++ b/reify_test.go
@@ -870,6 +870,9 @@ func TestUnpackStructWithArrConfig(t *testing.T) {
 	for name, test := range cases {
 		test := test
 		t.Run(name, func(t *testing.T) {
+			if name == "append" {
+				name = "append"
+			}
 			config := MustNewFrom(test.config)
 			err := config.Unpack(test.target.to)
 			if assert.NoError(t, err) {

--- a/reify_test.go
+++ b/reify_test.go
@@ -870,9 +870,6 @@ func TestUnpackStructWithArrConfig(t *testing.T) {
 	for name, test := range cases {
 		test := test
 		t.Run(name, func(t *testing.T) {
-			if name == "append" {
-				name = "append"
-			}
 			config := MustNewFrom(test.config)
 			err := config.Unpack(test.target.to)
 			if assert.NoError(t, err) {

--- a/util.go
+++ b/util.go
@@ -175,16 +175,25 @@ func isFloat(k reflect.Kind) bool {
 	}
 }
 
-func accessField(structVal reflect.Value, fieldIdx int, opts *options) (string, reflect.Type, reflect.Value, *options, tagOptions, string, bool) {
+type fieldInfo struct {
+	name          string
+	ftype         reflect.Type
+	value         reflect.Value
+	options       *options
+	tagOptions    tagOptions
+	validatorTags []validatorTag
+}
+
+func accessField(structVal reflect.Value, fieldIdx int, opts *options) (fieldInfo, bool, Error) {
 	stField := structVal.Type().Field(fieldIdx)
 
 	// ignore non exported fields
 	if rune, _ := utf8.DecodeRuneInString(stField.Name); !unicode.IsUpper(rune) {
-		return "", nil, reflect.Value{}, opts, tagOptions{}, "", true
+		return fieldInfo{}, true, nil
 	}
 	name, tagOpts := parseTags(stField.Tag.Get(opts.tag))
 	if tagOpts.ignore {
-		return "", nil, reflect.Value{}, opts, tagOpts, "", true
+		return fieldInfo{}, true, nil
 	}
 
 	// create new context, overwriting configValueHandling for all sub-operations
@@ -195,5 +204,17 @@ func accessField(structVal reflect.Value, fieldIdx int, opts *options) (string, 
 		opts = tmp
 	}
 
-	return fieldName(name, stField.Name), stField.Type, structVal.Field(fieldIdx), opts, tagOpts, stField.Tag.Get(opts.validatorTag), false
+	validators, err := parseValidatorTags(stField.Tag.Get(opts.validatorTag))
+	if err != nil {
+		return fieldInfo{}, false, raiseCritical(err, "")
+	}
+
+	return fieldInfo{
+		name:          fieldName(name, stField.Name),
+		ftype:         stField.Type,
+		value:         structVal.Field(fieldIdx),
+		options:       opts,
+		tagOptions:    tagOpts,
+		validatorTags: validators,
+	}, false, nil
 }

--- a/validator.go
+++ b/validator.go
@@ -167,15 +167,15 @@ func validateStruct(val reflect.Value, opts *options) error {
 	val = chaseValue(val)
 	numField := val.NumField()
 	for i := 0; i < numField; i++ {
-		_, _, vField, opts, _, vString, skip := accessField(val, i, opts)
+		fInfo, skip, err := accessField(val, i, opts)
+		if err != nil {
+			return err
+		}
 		if skip {
 			continue
 		}
-		validators, err := parseValidatorTags(vString)
-		if err != nil {
-			return raiseCritical(err, "")
-		}
-		if err := tryRecursiveValidate(vField, opts, validators); err != nil {
+
+		if err := tryRecursiveValidate(fInfo.value, fInfo.options, fInfo.validatorTags); err != nil {
 			return err
 		}
 	}

--- a/validator_test.go
+++ b/validator_test.go
@@ -878,6 +878,14 @@ func TestValidationFailOnDefaults(t *testing.T) {
 				I: -1,
 			},
 		},
+
+		// validate array
+		&myNonzeroList{0},
+
+		// validate map
+		&myNonzeroMap{
+			"zero": 0,
+		},
 	}
 
 	for i, test := range tests {

--- a/validator_test.go
+++ b/validator_test.go
@@ -19,6 +19,7 @@ package ucfg
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 	"testing"
 	"time"
@@ -43,6 +44,10 @@ type structMapValidator struct {
 type structNestedValidator struct {
 	I int
 	N structMapValidator
+}
+
+type structWithValidationTags struct {
+	I int `validate:"positive"`
 }
 
 var errZeroTest = errors.New("value must not be 0")
@@ -279,10 +284,10 @@ func TestValidationPass(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		t.Logf("Test config (%v): %#v", i, test)
-
-		err := c.Unpack(test)
-		assert.NoError(t, err)
+		t.Run(fmt.Sprintf("Test config (%v): %#v", i, test), func(t *testing.T) {
+			err := c.Unpack(test)
+			assert.NoError(t, err)
+		})
 	}
 }
 
@@ -499,10 +504,10 @@ func TestValidationFail(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		t.Logf("Test config (%v): %#v", i, test)
-
-		err := c.Unpack(test)
-		assert.True(t, err != nil)
+		t.Run(fmt.Sprintf("Test config (%v): %#v", i, test), func(t *testing.T) {
+			err := c.Unpack(test)
+			assert.True(t, err != nil)
+		})
 	}
 }
 
@@ -535,13 +540,13 @@ func TestValidateRequiredFailing(t *testing.T) {
 		}{}},
 
 		// Access empty string field "b"
-		{ErrEmpty, &struct {
+		{ErrRequired, &struct {
 			B string `validate:"required"`
 		}{}},
-		{ErrEmpty, &struct {
+		{ErrRequired, &struct {
 			B *string `validate:"required"`
 		}{}},
-		{ErrEmpty, &struct {
+		{ErrRequired, &struct {
 			B *regexp.Regexp `validate:"required"`
 		}{}},
 
@@ -563,23 +568,23 @@ func TestValidateRequiredFailing(t *testing.T) {
 		}{}},
 
 		// Check empty []string field 'd'
-		{ErrEmpty, &struct {
+		{ErrRequired, &struct {
 			D []string `validate:"required"`
 		}{}},
 	}
 
 	for i, test := range tests {
-		t.Logf("Test config (%v): %#v => %v", i, test.config, test.err)
+		t.Run(fmt.Sprintf("Test config (%v): %#v => %v", i, test.config, test.err), func(t *testing.T) {
+			err := c.Unpack(test.config)
+			if err == nil {
+				t.Error("Expected error")
+				return
+			}
 
-		err := c.Unpack(test.config)
-		if err == nil {
-			t.Error("Expected error")
-			continue
-		}
-
-		t.Logf("Unpack returned error: %v", err)
-		err = err.(Error).Reason()
-		assert.Equal(t, test.err, err)
+			t.Logf("Unpack returned error: %v", err)
+			err = err.(Error).Reason()
+			assert.Equal(t, test.err, err)
+		})
 	}
 }
 
@@ -655,16 +660,230 @@ func TestValidateNonzeroFailing(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		t.Logf("Test config (%v): %#v => %v", i, test.config, test.err)
+		t.Run(fmt.Sprintf("Test config (%v): %#v => %v", i, test.config, test.err), func(t *testing.T) {
+			err := c.Unpack(test.config)
+			if err == nil {
+				t.Error("Expected error")
+				return
+			}
 
-		err := c.Unpack(test.config)
-		if err == nil {
-			t.Error("Expected error")
-			continue
-		}
+			t.Logf("Unpack returned error: %v", err)
+			err = err.(Error).Reason()
+			assert.Equal(t, test.err, err)
+		})
+	}
+}
 
-		t.Logf("Unpack returned error: %v", err)
-		err = err.(Error).Reason()
-		assert.Equal(t, test.err, err)
+func TestValidationFailOnDefaults(t *testing.T) {
+	c := New()
+
+	tests := []interface{}{
+		// test field 'a'
+		&struct {
+			X int `config:"a" validate:"nonzero"`
+		}{
+			X: 0,
+		},
+		&struct {
+			X myNonzeroInt `config:"a"`
+		}{
+			X: 0,
+		},
+		&struct {
+			Tmp structValidator `config:",inline"`
+		}{
+			Tmp: structValidator{
+				I: 0,
+			},
+		},
+		&struct {
+			Tmp ptrStructValidator `config:",inline"`
+		}{
+			Tmp: ptrStructValidator{
+				I: 0,
+			},
+		},
+		&struct {
+			X int `config:"a" validate:"min=10"`
+		}{
+			X: 9,
+		},
+		&struct {
+			X time.Duration `config:"a" validate:"nonzero"`
+		}{
+			X: time.Duration(0),
+		},
+		&struct {
+			X time.Duration `config:"a" validate:"min=10"`
+		}{
+			X: time.Duration(9),
+		},
+		&struct {
+			X time.Duration `config:"a" validate:"min=10ns"`
+		}{
+			X: time.Duration(9 * time.Nanosecond),
+		},
+
+		// test field 'b'
+		&struct {
+			X int `config:"b" validate:"max=8"`
+		}{
+			X: 9,
+		},
+		&struct {
+			X int `config:"b" validate:"min=20"`
+		}{
+			X: 19,
+		},
+		&struct {
+			X time.Duration `config:"b" validate:"max=8ms"`
+		}{
+			X: time.Duration(9 * time.Millisecond),
+		},
+		&struct {
+			X time.Duration `config:"b" validate:"min=20h"`
+		}{
+			X: time.Duration(19 * time.Hour),
+		},
+
+		// test field 'd'
+		&struct {
+			X int `config:"d" validate:"positive"`
+		}{
+			X: -1,
+		},
+		&struct {
+			X int `config:"d" validate:"max=-11"`
+		}{
+			X: -10,
+		},
+		&struct {
+			X int `config:"d" validate:"min=20"`
+		}{
+			X: 19,
+		},
+		&struct {
+			X time.Duration `config:"d" validate:"positive"`
+		}{
+			X: time.Duration(-1),
+		},
+		&struct {
+			X time.Duration `config:"d" validate:"max=-11s"`
+		}{
+			X: time.Duration(-10 * time.Second),
+		},
+		&struct {
+			X time.Duration `config:"d" validate:"min=20h"`
+		}{
+			X: time.Duration(19 * time.Hour),
+		},
+
+		// test field 'f'
+		&struct {
+			X float64 `config:"f" validate:"max=1"`
+		}{
+			X: 2,
+		},
+		&struct {
+			X float64 `config:"f" validate:"min=20"`
+		}{
+			X: 19,
+		},
+		&struct {
+			X time.Duration `config:"f" validate:"max=1s"`
+		}{
+			X: time.Duration(2 * time.Second),
+		},
+		&struct {
+			X time.Duration `config:"f" validate:"min=20s"`
+		}{
+			X: time.Duration(19 * time.Second),
+		},
+
+		// test field 'l'
+		&struct {
+			X myCustomList `config:"l"`
+		}{
+			X: myCustomList{},
+		},
+
+		// validation field 'm'
+		&struct {
+			M myCustomMap
+		}{
+			M: myCustomMap{},
+		},
+
+		// validation field 'n'
+		&struct {
+			N myNonzeroList
+		}{
+			N: myNonzeroList{0},
+		},
+
+		// validation field 'o'
+		&struct {
+			O myNonzeroMap
+		}{
+			O: myNonzeroMap{
+				"zero": 0,
+			},
+		},
+
+		// validation 'p' field
+		&struct {
+			P mapValidator `config:"p"`
+		}{
+			P: mapValidator{
+				"zero": 0,
+			},
+		},
+
+		// validation 'q' field
+		&struct {
+			Q structMapValidator
+		}{
+			Q: structMapValidator{
+				I: 0,
+			},
+		},
+
+		// validation 'r' field
+		&struct {
+			R structNestedValidator
+		}{
+			R: structNestedValidator{
+				I: 0,
+			},
+		},
+		&struct {
+			R *structNestedValidator
+		}{
+			R: &structNestedValidator{
+				I: 1,
+				N: structMapValidator{
+					I: 1,
+					M: mapValidator{
+						"one": 1,
+					},
+				},
+			},
+		},
+
+		// validation 's' field
+		&struct {
+			S *structWithValidationTags
+		}{
+			S: &structWithValidationTags{
+				I: -1,
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("Test config (%v): %#v", i, test), func(t *testing.T) {
+			err := c.Unpack(test)
+			assert.True(t, err != nil)
+		})
 	}
 }


### PR DESCRIPTION
When unpacking into an object that already has values present but the configuration doesn't contains values for those objects still apply validation to the objects existing values. This is to ensure that even defaults that might already be set in the object that is passed to Unpack adheres to the same validation rules that the configuration must adhere to.

This also contains a fix on how validateRequired would return an ErrEmpty error instead of an ErrRequired. When using the `validate:"required"` tag the error message should match the tag applied.

Closes #42 