### PR TITLE
Prevent Validate from being called when value is a pointer or interface and is nil.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+- Prevent Validate from being called when value is a pointer or interface and is nil. #144
 
 ## [0.8.0]
 

--- a/validator.go
+++ b/validator.go
@@ -151,6 +151,11 @@ func tryRecursiveValidate(val reflect.Value, opts *options, validators []validat
 		return nil
 	}
 
+	t := val.Type()
+	if (t.Kind() == reflect.Ptr || t.Kind() == reflect.Interface) && val.IsNil() {
+		return nil
+	}
+
 	var err error
 	switch chaseValue(val).Kind() {
 	case reflect.Struct:

--- a/validator.go
+++ b/validator.go
@@ -110,6 +110,10 @@ func tryValidate(val reflect.Value) error {
 	t := val.Type()
 	var validator Validator
 
+	if (t.Kind() == reflect.Ptr || t.Kind() == reflect.Interface) && val.IsNil() {
+		return nil
+	}
+
 	if t.Implements(tValidator) {
 		validator = val.Interface().(Validator)
 	} else if reflect.PtrTo(t).Implements(tValidator) {

--- a/validator_test.go
+++ b/validator_test.go
@@ -50,6 +50,16 @@ type structWithValidationTags struct {
 	I int `validate:"positive"`
 }
 
+type nestedPtrStructValidator struct {
+	A *ptrStructValidator `validate:"required"`
+	B *ptrStructValidator `validate:"required"`
+}
+
+type nestedNestedPtrStructValidator struct {
+	A *nestedPtrStructValidator
+	B *nestedPtrStructValidator
+}
+
 var errZeroTest = errors.New("value must not be 0")
 var errEmptyTest = errors.New("value must not be empty")
 var errMoreTest = errors.New("value must have more than 1 element")
@@ -284,6 +294,11 @@ func TestValidationPass(t *testing.T) {
 		&struct {
 			X *ptrStructValidator // Validator not called as its nil value
 		}{},
+		&struct {
+			X *nestedNestedPtrStructValidator
+		}{
+			X: &nestedNestedPtrStructValidator{},
+		},
 	}
 
 	for i, test := range tests {
@@ -504,6 +519,11 @@ func TestValidationFail(t *testing.T) {
 		&struct {
 			X int `validate:"required"`
 		}{},
+		&struct {
+			X *nestedPtrStructValidator
+		}{
+			X: &nestedPtrStructValidator{},
+		},
 	}
 
 	for i, test := range tests {

--- a/validator_test.go
+++ b/validator_test.go
@@ -281,6 +281,9 @@ func TestValidationPass(t *testing.T) {
 		&struct {
 			X int // field not present in config, but not required
 		}{},
+		&struct {
+			X *ptrStructValidator // Validator not called as its nil value
+		}{},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Prevents Validate from being called when value is a pointer or interface and is nil.

Closes #144 