### PR TITLE
Fix nonzero validator to not validate nil array or slices.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+- Fixed nonzero validator to not fail on nil array or slice. #147
+- Fixed nonzero validator to validate maps.
+- Fixed required validator to validate maps.
 
 ## [0.8.1]
 

--- a/error.go
+++ b/error.go
@@ -98,6 +98,10 @@ var (
 	ErrRequired = errors.New("missing required field")
 
 	ErrEmpty = errors.New("empty field")
+
+	ErrArrayEmpty = errors.New("empty array")
+
+	ErrMapEmpty = errors.New("empty map")
 )
 
 // Error Classes

--- a/error.go
+++ b/error.go
@@ -102,6 +102,10 @@ var (
 	ErrArrayEmpty = errors.New("empty array")
 
 	ErrMapEmpty = errors.New("empty map")
+
+	ErrRegexEmpty = errors.New("regex value is not set")
+
+	ErrStringEmpty = errors.New("string value is not set")
 )
 
 // Error Classes

--- a/validator.go
+++ b/validator.go
@@ -392,13 +392,17 @@ func validateRequired(v interface{}, name string) error {
 		}
 		return nil
 	}
-	if err := validateNonEmpty(v, name); err != nil {
+	if err := validateNonEmptyWithAllowNil(v, name, false); err != nil {
 		return ErrRequired
 	}
 	return nil
 }
 
-func validateNonEmpty(v interface{}, _ string) error {
+func validateNonEmpty(v interface{}, name string) error {
+	return validateNonEmptyWithAllowNil(v, name, true)
+}
+
+func validateNonEmptyWithAllowNil(v interface{}, _ string, allowNil bool) error {
 	if s, ok := v.(string); ok {
 		if s == "" {
 			return ErrEmpty
@@ -414,7 +418,10 @@ func validateNonEmpty(v interface{}, _ string) error {
 	}
 
 	val := reflect.ValueOf(v)
-	if val.Kind() == reflect.Array || val.Kind() == reflect.Slice {
+	if val.Kind() == reflect.Array || val.Kind() == reflect.Slice || val.Kind() == reflect.Map {
+		if allowNil && val.IsNil() {
+			return nil
+		}
 		if val.Len() == 0 {
 			return ErrEmpty
 		}

--- a/validator.go
+++ b/validator.go
@@ -393,7 +393,7 @@ func validateRequired(v interface{}, name string) error {
 		return nil
 	}
 	if err := validateNonEmptyWithAllowNil(v, name, false); err != nil {
-		return ErrRequired
+		return err
 	}
 	return nil
 }
@@ -418,12 +418,21 @@ func validateNonEmptyWithAllowNil(v interface{}, _ string, allowNil bool) error 
 	}
 
 	val := reflect.ValueOf(v)
-	if val.Kind() == reflect.Array || val.Kind() == reflect.Slice || val.Kind() == reflect.Map {
+	if val.Kind() == reflect.Array || val.Kind() == reflect.Slice {
 		if allowNil && val.IsNil() {
 			return nil
 		}
 		if val.Len() == 0 {
-			return ErrEmpty
+			return ErrArrayEmpty
+		}
+		return nil
+	}
+	if val.Kind() == reflect.Map {
+		if allowNil && val.IsNil() {
+			return nil
+		}
+		if val.Len() == 0 {
+			return ErrMapEmpty
 		}
 		return nil
 	}

--- a/validator.go
+++ b/validator.go
@@ -405,14 +405,14 @@ func validateNonEmpty(v interface{}, name string) error {
 func validateNonEmptyWithAllowNil(v interface{}, _ string, allowNil bool) error {
 	if s, ok := v.(string); ok {
 		if s == "" {
-			return ErrEmpty
+			return ErrStringEmpty
 		}
 		return nil
 	}
 
 	if r, ok := v.(regexp.Regexp); ok {
 		if r.String() == "" {
-			return ErrEmpty
+			return ErrRegexEmpty
 		}
 		return nil
 	}

--- a/validator.go
+++ b/validator.go
@@ -419,8 +419,11 @@ func validateNonEmptyWithAllowNil(v interface{}, _ string, allowNil bool) error 
 
 	val := reflect.ValueOf(v)
 	if val.Kind() == reflect.Array || val.Kind() == reflect.Slice {
-		if allowNil && val.IsNil() {
-			return nil
+		if val.IsNil() {
+			if allowNil {
+				return nil
+			}
+			return ErrRequired
 		}
 		if val.Len() == 0 {
 			return ErrArrayEmpty
@@ -428,8 +431,11 @@ func validateNonEmptyWithAllowNil(v interface{}, _ string, allowNil bool) error 
 		return nil
 	}
 	if val.Kind() == reflect.Map {
-		if allowNil && val.IsNil() {
-			return nil
+		if val.IsNil() {
+			if allowNil {
+				return nil
+			}
+			return ErrRequired
 		}
 		if val.Len() == 0 {
 			return ErrMapEmpty

--- a/validator_test.go
+++ b/validator_test.go
@@ -559,10 +559,10 @@ func TestValidateRequiredFailing(t *testing.T) {
 		{ErrRequired, &struct {
 			A int `validate:"required"`
 		}{}},
-		{ErrEmpty, &struct {
+		{ErrStringEmpty, &struct {
 			A string `validate:"required"`
 		}{}},
-		{ErrArrayEmpty, &struct {
+		{ErrRequired, &struct {
 			A []string `validate:"required"`
 		}{}},
 		{ErrRequired, &struct {
@@ -570,13 +570,13 @@ func TestValidateRequiredFailing(t *testing.T) {
 		}{}},
 
 		// Access empty string field "b"
-		{ErrEmpty, &struct {
+		{ErrStringEmpty, &struct {
 			B string `validate:"required"`
 		}{}},
-		{ErrEmpty, &struct {
+		{ErrStringEmpty, &struct {
 			B *string `validate:"required"`
 		}{}},
-		{ErrEmpty, &struct {
+		{ErrRegexEmpty, &struct {
 			B *regexp.Regexp `validate:"required"`
 		}{}},
 
@@ -587,10 +587,10 @@ func TestValidateRequiredFailing(t *testing.T) {
 		{ErrRequired, &struct {
 			C int `validate:"required"`
 		}{}},
-		{ErrEmpty, &struct {
+		{ErrStringEmpty, &struct {
 			C string `validate:"required"`
 		}{}},
-		{ErrArrayEmpty, &struct {
+		{ErrRequired, &struct {
 			C []string `validate:"required"`
 		}{}},
 		{ErrRequired, &struct {
@@ -690,13 +690,13 @@ func TestValidateNonzeroFailing(t *testing.T) {
 		}{}},
 
 		// test string types accessing 's'
-		{ErrEmpty, &struct {
+		{ErrStringEmpty, &struct {
 			S string `validate:"nonzero"`
 		}{}},
-		{ErrEmpty, &struct {
+		{ErrStringEmpty, &struct {
 			S *string `validate:"nonzero"`
 		}{}},
-		{ErrEmpty, &struct {
+		{ErrRegexEmpty, &struct {
 			S *regexp.Regexp `validate:"nonzero"`
 		}{}},
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -299,6 +299,12 @@ func TestValidationPass(t *testing.T) {
 		}{
 			X: &nestedNestedPtrStructValidator{},
 		},
+		&struct {
+			X []string `validate:"nonzero"` // field not present in config, nonzero (no error)
+		}{},
+		&struct {
+			X map[string]string `validate:"nonzero"` // field not present in config, nonzero (no error)
+		}{},
 	}
 
 	for i, test := range tests {
@@ -539,6 +545,7 @@ func TestValidateRequiredFailing(t *testing.T) {
 		"b": "",
 		"c": nil,
 		"d": []string{},
+		"f": map[string]string{},
 	})
 
 	tests := []struct {
@@ -590,10 +597,29 @@ func TestValidateRequiredFailing(t *testing.T) {
 			C time.Duration `validate:"required"`
 		}{}},
 
-		// Check empty []string field 'd'
+		// Check required []string field 'd'
 		{ErrRequired, &struct {
 			D []string `validate:"required"`
 		}{}},
+
+		// Check required []string filed 'e' not in config (pre-initialized)
+		{ErrRequired, &struct {
+			E []string `validate:"required"`
+		}{
+			E: []string{},
+		}},
+
+		// Check empty map[string]string field 'f'
+		{ErrRequired, &struct {
+			F map[string]string `validate:"required"`
+		}{}},
+
+		// Check required map[string] 'g' not in config (pre-initialized)
+		{ErrRequired, &struct {
+			G map[string]string `validate:"required"`
+		}{
+			G: map[string]string{},
+		}},
 	}
 
 	for i, test := range tests {
@@ -616,6 +642,7 @@ func TestValidateNonzeroFailing(t *testing.T) {
 		"i": 0,
 		"s": "",
 		"a": []int{},
+		"c": map[string]string{},
 	})
 
 	tests := []struct {
@@ -680,6 +707,38 @@ func TestValidateNonzeroFailing(t *testing.T) {
 		{ErrEmpty, &struct {
 			A []uint8 `validate:"nonzero"`
 		}{}},
+
+		// test array type accessing 'b' (pre-initialized)
+		{ErrEmpty, &struct {
+			B []int `validate:"nonzero"`
+		}{
+			B: []int{},
+		}},
+		{ErrEmpty, &struct {
+			B []uint8 `validate:"nonzero"`
+		}{
+			B: []uint8{},
+		}},
+
+		// test array type accessing 'c'
+		{ErrEmpty, &struct {
+			C map[string]string `validate:"nonzero"`
+		}{}},
+		{ErrEmpty, &struct {
+			C map[string]string `validate:"nonzero"`
+		}{}},
+
+		// test array type accessing 'd' (pre-initialized)
+		{ErrEmpty, &struct {
+			D map[string]string `validate:"nonzero"`
+		}{
+			D: map[string]string{},
+		}},
+		{ErrEmpty, &struct {
+			D map[string]string `validate:"nonzero"`
+		}{
+			D: map[string]string{},
+		}},
 	}
 
 	for i, test := range tests {

--- a/validator_test.go
+++ b/validator_test.go
@@ -559,10 +559,10 @@ func TestValidateRequiredFailing(t *testing.T) {
 		{ErrRequired, &struct {
 			A int `validate:"required"`
 		}{}},
-		{ErrRequired, &struct {
+		{ErrEmpty, &struct {
 			A string `validate:"required"`
 		}{}},
-		{ErrRequired, &struct {
+		{ErrArrayEmpty, &struct {
 			A []string `validate:"required"`
 		}{}},
 		{ErrRequired, &struct {
@@ -570,13 +570,13 @@ func TestValidateRequiredFailing(t *testing.T) {
 		}{}},
 
 		// Access empty string field "b"
-		{ErrRequired, &struct {
+		{ErrEmpty, &struct {
 			B string `validate:"required"`
 		}{}},
-		{ErrRequired, &struct {
+		{ErrEmpty, &struct {
 			B *string `validate:"required"`
 		}{}},
-		{ErrRequired, &struct {
+		{ErrEmpty, &struct {
 			B *regexp.Regexp `validate:"required"`
 		}{}},
 
@@ -587,10 +587,10 @@ func TestValidateRequiredFailing(t *testing.T) {
 		{ErrRequired, &struct {
 			C int `validate:"required"`
 		}{}},
-		{ErrRequired, &struct {
+		{ErrEmpty, &struct {
 			C string `validate:"required"`
 		}{}},
-		{ErrRequired, &struct {
+		{ErrArrayEmpty, &struct {
 			C []string `validate:"required"`
 		}{}},
 		{ErrRequired, &struct {
@@ -598,24 +598,24 @@ func TestValidateRequiredFailing(t *testing.T) {
 		}{}},
 
 		// Check required []string field 'd'
-		{ErrRequired, &struct {
+		{ErrArrayEmpty, &struct {
 			D []string `validate:"required"`
 		}{}},
 
 		// Check required []string filed 'e' not in config (pre-initialized)
-		{ErrRequired, &struct {
+		{ErrArrayEmpty, &struct {
 			E []string `validate:"required"`
 		}{
 			E: []string{},
 		}},
 
 		// Check empty map[string]string field 'f'
-		{ErrRequired, &struct {
+		{ErrMapEmpty, &struct {
 			F map[string]string `validate:"required"`
 		}{}},
 
 		// Check required map[string] 'g' not in config (pre-initialized)
-		{ErrRequired, &struct {
+		{ErrMapEmpty, &struct {
 			G map[string]string `validate:"required"`
 		}{
 			G: map[string]string{},
@@ -701,40 +701,40 @@ func TestValidateNonzeroFailing(t *testing.T) {
 		}{}},
 
 		// test array type accessing 'a'
-		{ErrEmpty, &struct {
+		{ErrArrayEmpty, &struct {
 			A []int `validate:"nonzero"`
 		}{}},
-		{ErrEmpty, &struct {
+		{ErrArrayEmpty, &struct {
 			A []uint8 `validate:"nonzero"`
 		}{}},
 
 		// test array type accessing 'b' (pre-initialized)
-		{ErrEmpty, &struct {
+		{ErrArrayEmpty, &struct {
 			B []int `validate:"nonzero"`
 		}{
 			B: []int{},
 		}},
-		{ErrEmpty, &struct {
+		{ErrArrayEmpty, &struct {
 			B []uint8 `validate:"nonzero"`
 		}{
 			B: []uint8{},
 		}},
 
 		// test array type accessing 'c'
-		{ErrEmpty, &struct {
+		{ErrMapEmpty, &struct {
 			C map[string]string `validate:"nonzero"`
 		}{}},
-		{ErrEmpty, &struct {
+		{ErrMapEmpty, &struct {
 			C map[string]string `validate:"nonzero"`
 		}{}},
 
 		// test array type accessing 'd' (pre-initialized)
-		{ErrEmpty, &struct {
+		{ErrMapEmpty, &struct {
 			D map[string]string `validate:"nonzero"`
 		}{
 			D: map[string]string{},
 		}},
-		{ErrEmpty, &struct {
+		{ErrMapEmpty, &struct {
 			D map[string]string `validate:"nonzero"`
 		}{
 			D: map[string]string{},


### PR DESCRIPTION
Fixes issue where the `nonzero` validator would fail when the array or slice was `nil` value.

This also includes fixes for map types where nonzero or required would not validate them correctly.

Closes elastic/go-ucfg#147 