### PR TITLE
Add ability to adjust merging behavior of configs per fields defined in configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Added ability to adjust merging behavior based on field names in configuration. Using `ucfg.FieldDefaultValues`, `ucfg.FieldReplaceValues`, `ucfg.FieldAppendValues`, and `ucfg.FieldPrependValues`. #151
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
-- Added ability to adjust merging behavior based on field names in configuration. Using `ucfg.FieldDefaultValues`, `ucfg.FieldReplaceValues`, `ucfg.FieldAppendValues`, and `ucfg.FieldPrependValues`. #151
+- Added ability to adjust merging behavior based on field names in configuration. Using `ucfg.FieldMergeValues`, `ucfg.FieldReplaceValues`, `ucfg.FieldAppendValues`, and `ucfg.FieldPrependValues`. #151
 
 ### Changed
 

--- a/merge.go
+++ b/merge.go
@@ -89,7 +89,7 @@ func mergeConfig(opts *options, to, from *Config) Error {
 	if err := mergeConfigDict(opts, to, from); err != nil {
 		return err
 	}
-	return mergeConfigArr(fieldOptsOverride(opts, "*"), to, from)
+	return mergeConfigArr(opts, to, from)
 }
 
 func mergeConfigDict(opts *options, to, from *Config) Error {
@@ -131,18 +131,18 @@ func mergeConfigDict(opts *options, to, from *Config) Error {
 func mergeConfigArr(opts *options, to, from *Config) Error {
 	switch opts.configValueHandling {
 	case cfgReplaceValue:
-		return mergeConfigReplaceArr(opts, to, from)
+		return mergeConfigReplaceArr(fieldOptsOverride(opts, "*"), to, from)
 
 	case cfgArrPrepend:
-		return mergeConfigPrependArr(opts, to, from)
+		return mergeConfigPrependArr(fieldOptsOverride(opts, "*"), to, from)
 
 	case cfgArrAppend:
-		return mergeConfigAppendArr(opts, to, from)
+		return mergeConfigAppendArr(fieldOptsOverride(opts, "*"), to, from)
 
 	case cfgDefaultHandling, cfgMergeValues:
-		return mergeConfigMergeArr(opts, to, from)
+		return mergeConfigMergeArr(fieldOptsOverride(opts, "*"), to, from)
 	default:
-		return mergeConfigMergeArr(opts, to, from)
+		return mergeConfigMergeArr(fieldOptsOverride(opts, "*"), to, from)
 	}
 }
 

--- a/merge.go
+++ b/merge.go
@@ -523,6 +523,10 @@ func fieldOptsOverride(opts *options, fieldName string) *options {
 	}
 	cfgHandling, ok := opts.fieldValueHandling[fieldName]
 	if !ok {
+		// possible unknown depth defined
+		cfgHandling, ok = opts.fieldValueHandling[fmt.Sprintf("**.%s", fieldName)]
+	}
+	if !ok {
 		if len(opts.fieldValueHandling) != 0 {
 			// need to remove a level of fields as a nested field could have a
 			// config handling modification
@@ -549,8 +553,12 @@ func trimFieldConfigHandlingLevel(fieldName string, pathSep string, m map[string
 	nested := make(map[string]configHandling)
 	for k, v := range m {
 		s := strings.SplitN(k, pathSep, 2)
-		if len(s) == 2 && s[0] == fieldName {
-			nested[s[1]] = v
+		if len(s) == 2 {
+			if s[0] == fieldName {
+				nested[s[1]] = v
+			} else if s[0] == "**" {
+				nested[k] = v
+			}
 		}
 	}
 	return nested

--- a/merge_test.go
+++ b/merge_test.go
@@ -390,6 +390,49 @@ func TestMergeChildArray(t *testing.T) {
 	}
 }
 
+func TestMergeArrayOfMaps(t *testing.T) {
+	c := New()
+	err := c.Merge(map[string]interface{}{
+		"paths": []interface{}{
+			"removed_1.log",
+			"removed_2.log",
+			"removed_2.log",
+		},
+		"processors": []interface{}{
+			map[string]interface{}{
+				"add_locale": map[string]interface{}{},
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	err = c.Merge(map[string]interface{}{
+		"paths": []interface{}{
+			"container.log",
+		},
+		"processors": []interface{}{
+			map[string]interface{}{
+				"add_fields": map[string]interface{}{
+					"foo": "bar",
+				},
+			},
+		},
+	},
+		PathSep("."),
+		FieldReplaceValues("paths"), FieldDefaultValues("paths.*"),
+		FieldAppendValues("processors"), FieldDefaultValues("processors.*"))
+	assert.NoError(t, err)
+
+	unpacked := make(map[string]interface{})
+	assert.NoError(t, c.Unpack(unpacked))
+
+	paths, _ := unpacked["paths"]
+	assert.Len(t, paths, 1)
+
+	processors, _ := unpacked["processors"]
+	assert.Len(t, processors, 2)
+}
+
 func TestMergeSquash(t *testing.T) {
 	type SubType struct{ B bool }
 	type SubInterface struct{ B interface{} }

--- a/opts.go
+++ b/opts.go
@@ -38,6 +38,7 @@ type options struct {
 	noParse      bool
 
 	configValueHandling configHandling
+	fieldValueHandling  map[string]configHandling
 
 	// temporary cache of parsed splice values for lifetime of call to
 	// Unpack/Pack/Get/...
@@ -159,6 +160,43 @@ var (
 func makeOptValueHandling(h configHandling) Option {
 	return func(o *options) {
 		o.configValueHandling = h
+	}
+}
+
+var (
+	// FieldDefaultValues option configures all merging and unpacking operations to
+	// use the default merging for the specified field. This overrides the any struct
+	// tags during unpack for the field. Nested field names can be defined using dot
+	// notation.
+	FieldDefaultValues = makeFieldOptValueHandling(cfgDefaultHandling)
+
+	// FieldReplaceValues option configures all merging and unpacking operations to
+	// replace old dictionaries and arrays while merging for the specified field. This
+	// overrides the any struct tags during unpack for the field. Nested field names
+	// can be defined using dot notation.
+	FieldReplaceValues = makeFieldOptValueHandling(cfgReplaceValue)
+
+	// FieldAppendValues option configures all merging and unpacking operations to
+	// merge dictionaries and append arrays to existing arrays while merging for the
+	// specified field. This overrides the any struct tags during unpack for the field.
+	// Nested field names can be defined using dot notation.
+	FieldAppendValues = makeFieldOptValueHandling(cfgArrAppend)
+
+	// FieldPrependValues option configures all merging and unpacking operations to
+	// merge dictionaries and prepend arrays to existing arrays while merging for the
+	// specified field. This overrides the any struct tags during unpack for the field.
+	// Nested field names can be defined using dot notation.
+	FieldPrependValues = makeFieldOptValueHandling(cfgArrPrepend)
+)
+
+func makeFieldOptValueHandling(h configHandling) func(string) Option {
+	return func(fieldName string) Option {
+		return func(o *options) {
+			if o.fieldValueHandling == nil {
+				o.fieldValueHandling = make(map[string]configHandling)
+			}
+			o.fieldValueHandling[fieldName] = h
+		}
 	}
 }
 


### PR DESCRIPTION
Adds the ability to adjust merging behavior of configs per fields defined in configurations.

Below is the user experience that this change provides:

```
cfg.Merge(
   other,
   ucfg.FieldReplaceValues("paths"),
   ucfg.FieldAppendValues("processors"),
)
```

This would allow a `paths` field to be replaced with any values from `other` and the `processors` field to be appended with values from `other`. Indexes into arrays can also be used to adjust the merging behavior at that index in the array (eg. `FieldAppendValues("processors.2.add_tags.tags"`). 

In the case that the depths of the fields are unknown but that behavior should always occur when fields of that name are reached in the merging process then the `**.{name}` selector can be used.

`ucfg.FieldReplaceValues("**.paths")` will ensure that replace is always performed when a field name `paths` is reached no matter its depth in the configuration. Nesting of wildcard is also supported with say `"subpath.**.paths"`.

Closes elastic/go-ucfg#151 