### PR TITLE
Remove testify/assert from Validator Tests

### DIFF
--- a/validator_test.go
+++ b/validator_test.go
@@ -637,7 +637,11 @@ func TestValidateRequiredFailing(t *testing.T) {
 
 			t.Logf("Unpack returned error: %v", err)
 			err = err.(Error).Reason()
-			assert.Equal(t, test.err, err)
+			logTmpl := "expected:%q got:%q"
+			if test.err != err {
+				t.Fatalf(logTmpl, test.err, err)
+			}
+			t.Logf(logTmpl, test.err, err)
 		})
 	}
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -64,7 +64,17 @@ var errZeroTest = errors.New("value must not be 0")
 var errEmptyTest = errors.New("value must not be empty")
 var errMoreTest = errors.New("value must have more than 1 element")
 
-var validateErrorTemplate = "config:%s test:%s error:%v"
+func mustFailUnpack(t *testing.T, cfg *Config, test interface{}) {
+	if err := cfg.Unpack(test); err == nil {
+		t.Fatalf("config:%s test:%s error:%v", spew.Sdump(cfg), spew.Sdump(test), err)
+	}
+}
+
+func mustUnpack(t *testing.T, cfg *Config, test interface{}) {
+	if err := cfg.Unpack(test); err != nil {
+		t.Fatalf("config:%s test:%s error:%v", spew.Sdump(cfg), spew.Sdump(test), err)
+	}
+}
 
 func (m myNonzeroInt) Validate() error {
 	return testZeroErr(int(m))
@@ -311,10 +321,7 @@ func TestValidationPass(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("Test config (%v): %#v", i, test), func(t *testing.T) {
-			err := c.Unpack(test)
-			if err != nil {
-				t.Fatalf(validateErrorTemplate, spew.Sdump(c), spew.Sdump(test), err)
-			}
+			mustUnpack(t, c, test)
 		})
 	}
 }
@@ -538,10 +545,7 @@ func TestValidationFail(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("Test config (%v): %#v", i, test), func(t *testing.T) {
-			err := c.Unpack(test)
-			if err == nil {
-				t.Fatalf(validateErrorTemplate, spew.Sdump(c), spew.Sdump(test), err)
-			}
+			mustFailUnpack(t, c, test)
 		})
 	}
 }
@@ -986,11 +990,7 @@ func TestValidationFailOnDefaults(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("Test config (%v): %#v", i, test), func(t *testing.T) {
-			err := c.Unpack(test)
-			if err == nil {
-				t.Fatalf(validateErrorTemplate, spew.Sdump(c), spew.Sdump(test), err)
-			}
-
+			mustFailUnpack(t, c, test)
 		})
 	}
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -538,7 +538,9 @@ func TestValidationFail(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("Test config (%v): %#v", i, test), func(t *testing.T) {
 			err := c.Unpack(test)
-			assert.True(t, err != nil)
+			if err == nil {
+				t.Fatalf("test:%v error:%v", spew.Sdump(test), err)
+			}
 		})
 	}
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -310,7 +311,9 @@ func TestValidationPass(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("Test config (%v): %#v", i, test), func(t *testing.T) {
 			err := c.Unpack(test)
-			assert.NoError(t, err)
+			if err != nil {
+				t.Fatalf("test:%v error:%v", spew.Sdump(test), err)
+			}
 		})
 	}
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -64,6 +64,8 @@ var errZeroTest = errors.New("value must not be 0")
 var errEmptyTest = errors.New("value must not be empty")
 var errMoreTest = errors.New("value must have more than 1 element")
 
+var validateErrorTemplate = "config:%s test:%s error:%v"
+
 func (m myNonzeroInt) Validate() error {
 	return testZeroErr(int(m))
 }
@@ -311,7 +313,7 @@ func TestValidationPass(t *testing.T) {
 		t.Run(fmt.Sprintf("Test config (%v): %#v", i, test), func(t *testing.T) {
 			err := c.Unpack(test)
 			if err != nil {
-				t.Fatalf("test:%v error:%v", spew.Sdump(test), err)
+				t.Fatalf(validateErrorTemplate, spew.Sdump(c), spew.Sdump(test), err)
 			}
 		})
 	}
@@ -538,7 +540,7 @@ func TestValidationFail(t *testing.T) {
 		t.Run(fmt.Sprintf("Test config (%v): %#v", i, test), func(t *testing.T) {
 			err := c.Unpack(test)
 			if err == nil {
-				t.Fatalf("test:%v error:%v", spew.Sdump(test), err)
+				t.Fatalf(validateErrorTemplate, spew.Sdump(c), spew.Sdump(test), err)
 			}
 		})
 	}
@@ -986,7 +988,7 @@ func TestValidationFailOnDefaults(t *testing.T) {
 		t.Run(fmt.Sprintf("Test config (%v): %#v", i, test), func(t *testing.T) {
 			err := c.Unpack(test)
 			if err == nil {
-				t.Fatalf("test:%v error:%v", spew.Sdump(test), err)
+				t.Fatalf(validateErrorTemplate, spew.Sdump(c), spew.Sdump(test), err)
 			}
 
 		})

--- a/validator_test.go
+++ b/validator_test.go
@@ -760,7 +760,11 @@ func TestValidateNonzeroFailing(t *testing.T) {
 
 			t.Logf("Unpack returned error: %v", err)
 			err = err.(Error).Reason()
-			assert.Equal(t, test.err, err)
+			logTmpl := "expected:%q got:%q"
+			if test.err != err {
+				t.Fatalf(logTmpl, test.err, err)
+			}
+			t.Logf(logTmpl, test.err, err)
 		})
 	}
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/stretchr/testify/assert"
 )
 
 type myNonzeroInt int
@@ -986,7 +985,10 @@ func TestValidationFailOnDefaults(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("Test config (%v): %#v", i, test), func(t *testing.T) {
 			err := c.Unpack(test)
-			assert.True(t, err != nil)
+			if err == nil {
+				t.Fatalf("test:%v error:%v", spew.Sdump(test), err)
+			}
+
 		})
 	}
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -642,11 +642,9 @@ func TestValidateRequiredFailing(t *testing.T) {
 
 			t.Logf("Unpack returned error: %v", err)
 			err = err.(Error).Reason()
-			logTmpl := "expected:%q got:%q"
 			if test.err != err {
-				t.Fatalf(logTmpl, test.err, err)
+				t.Fatalf("expected:%q got:%q", test.err, err)
 			}
-			t.Logf(logTmpl, test.err, err)
 		})
 	}
 }
@@ -765,11 +763,9 @@ func TestValidateNonzeroFailing(t *testing.T) {
 
 			t.Logf("Unpack returned error: %v", err)
 			err = err.(Error).Reason()
-			logTmpl := "expected:%q got:%q"
 			if test.err != err {
-				t.Fatalf(logTmpl, test.err, err)
+				t.Fatalf("expected:%q got:%q", test.err, err)
 			}
-			t.Logf(logTmpl, test.err, err)
 		})
 	}
 }


### PR DESCRIPTION
Hi, @urso.

I've dipped my toe in the water of removing `assert`, as mentioned in https://github.com/elastic/go-ucfg/issues/156.

This removes `testify/assert` from only one test file in the `ucfg` package, and it brings in `go-spew` to improve the readability of test failures.

If this approach looks good to you, I'm happy to keep going, preferably one entire package per PR.