### PR TITLE
Fix: check if target is valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+- Fixed panic on zero Value while processing a collection of interfaces. #159
 
 ## [0.8.3]
 

--- a/cfgtest/unpack.go
+++ b/cfgtest/unpack.go
@@ -1,0 +1,25 @@
+package cfgtest
+
+import (
+	"github.com/davecgh/go-spew/spew"
+)
+
+type testingT interface {
+	Fatalf(format string, args ...interface{})
+}
+
+type config interface {
+	UnpackWithoutOptions(to interface{}) error
+}
+
+func MustFailUnpack(t testingT, cfg config, test interface{}) {
+	if err := cfg.UnpackWithoutOptions(test); err == nil {
+		t.Fatalf("expected failure, config:%s test:%s", spew.Sdump(cfg), spew.Sdump(test))
+	}
+}
+
+func MustUnpack(t testingT, cfg config, test interface{}) {
+	if err := cfg.UnpackWithoutOptions(test); err != nil {
+		t.Fatalf("config:%s test:%s error:%v", spew.Sdump(cfg), spew.Sdump(test), err)
+	}
+}

--- a/cfgtest/unpack.go
+++ b/cfgtest/unpack.go
@@ -12,12 +12,14 @@ type config interface {
 	UnpackWithoutOptions(to interface{}) error
 }
 
+// MustFailUnpack method fails the testing if unpacking passed.
 func MustFailUnpack(t testingT, cfg config, test interface{}) {
 	if err := cfg.UnpackWithoutOptions(test); err == nil {
 		t.Fatalf("expected failure, config:%s test:%s", spew.Sdump(cfg), spew.Sdump(test))
 	}
 }
 
+// MustUnpack method fails the testing if unpacking failed too.
 func MustUnpack(t testingT, cfg config, test interface{}) {
 	if err := cfg.UnpackWithoutOptions(test); err != nil {
 		t.Fatalf("config:%s test:%s error:%v", spew.Sdump(cfg), spew.Sdump(test), err)

--- a/error_test.go
+++ b/error_test.go
@@ -231,7 +231,7 @@ func TestErrorMessages(t *testing.T) {
 // quotas and makes some test assertions failing.
 func adjustMessageFormat(message string) string {
 	runtimeVersion := runtime.Version()
-	if strings.HasPrefix(runtimeVersion, "go1.14") || strings.HasPrefix(runtimeVersion, "devel") {
+	if strings.HasPrefix(runtimeVersion, "devel") {
 		adjusted := strings.Replace(message, "unknown unit \"", "unknown unit ", 1)
 		adjusted = strings.Replace(adjusted, "\" in duration \"", " in duration ", 1)
 		adjusted = strings.Replace(adjusted, "\" accessing", " accessing", 1)

--- a/error_test.go
+++ b/error_test.go
@@ -25,6 +25,7 @@ import (
 	"path"
 	"reflect"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -229,8 +230,11 @@ func TestErrorMessages(t *testing.T) {
 // The change introduced in https://github.com/golang/go/commit/201cb046b745f8bb00e3d382290190c74ba7b7e1 added
 // quotas and makes some test assertions failing.
 func adjustMessageFormat(message string) string {
-	adjusted := strings.Replace(message, "unknown unit \"", "unknown unit ", 1)
-	adjusted = strings.Replace(adjusted, "\" in duration \"", " in duration ", 1)
-	adjusted = strings.Replace(adjusted, "\" accessing", " accessing", 1)
-	return adjusted
+	if strings.HasPrefix(runtime.Version(), "go1.14") {
+		adjusted := strings.Replace(message, "unknown unit \"", "unknown unit ", 1)
+		adjusted = strings.Replace(adjusted, "\" in duration \"", " in duration ", 1)
+		adjusted = strings.Replace(adjusted, "\" accessing", " accessing", 1)
+		return adjusted
+	}
+	return message
 }

--- a/error_test.go
+++ b/error_test.go
@@ -24,11 +24,8 @@ import (
 	"io/ioutil"
 	"path"
 	"reflect"
-	"regexp"
 	"runtime"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -51,8 +48,8 @@ func TestErrorMessages(t *testing.T) {
 	cNested.ctx = testNestedCtx
 	cNestedMeta.ctx = testNestedCtx
 
-	_, timeErr := time.ParseDuration("1 hour")
-	_, regexpErr := regexp.Compile(`[`)
+	timeErr := errors.New("time-err")
+	regexpErr := errors.New("regexp-err")
 
 	tests := map[string]Error{
 		"duplicate_wo_meta":        raiseDuplicateKey(c, "test"),
@@ -220,22 +217,7 @@ func TestErrorMessages(t *testing.T) {
 			}
 
 			golden := string(tmp)
-			message = adjustMessageFormat(message)
 			assert.Equal(t, golden, message, "Go runtime version: %s", runtime.Version())
 		})
 	}
-}
-
-// adjustMessageFormat method modifies the message to be backward compatible with previous Go releases.
-// The change introduced in https://github.com/golang/go/commit/201cb046b745f8bb00e3d382290190c74ba7b7e1 added
-// quotas and makes some test assertions failing.
-func adjustMessageFormat(message string) string {
-	runtimeVersion := runtime.Version()
-	if strings.HasPrefix(runtimeVersion, "devel") {
-		adjusted := strings.Replace(message, "unknown unit \"", "unknown unit ", 1)
-		adjusted = strings.Replace(adjusted, "\" in duration \"", " in duration ", 1)
-		adjusted = strings.Replace(adjusted, "\" accessing", " accessing", 1)
-		return adjusted
-	}
-	return message
 }

--- a/error_test.go
+++ b/error_test.go
@@ -25,6 +25,7 @@ import (
 	"path"
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -218,7 +219,17 @@ func TestErrorMessages(t *testing.T) {
 			}
 
 			golden := string(tmp)
+			message = adjustMessageFormat(message)
 			assert.Equal(t, golden, message)
 		})
 	}
+}
+
+// adjustMessageFormat method modifies the message to be backward compatible with previous Go releases.
+// The change introduced in https://github.com/golang/go/commit/201cb046b745f8bb00e3d382290190c74ba7b7e1 added
+// quotas and makes some test assertions failing.
+func adjustMessageFormat(message string) string {
+	adjusted := strings.Replace(message, "unknown unit \"", "unknown unit ", 1)
+	adjusted = strings.Replace(message, "\" in duration", " in duration", 1)
+	return adjusted
 }

--- a/error_test.go
+++ b/error_test.go
@@ -230,7 +230,8 @@ func TestErrorMessages(t *testing.T) {
 // The change introduced in https://github.com/golang/go/commit/201cb046b745f8bb00e3d382290190c74ba7b7e1 added
 // quotas and makes some test assertions failing.
 func adjustMessageFormat(message string) string {
-	if strings.HasPrefix(runtime.Version(), "go1.14") {
+	runtimeVersion := runtime.Version()
+	if strings.HasPrefix(runtimeVersion, "go1.14") || strings.HasPrefix(runtimeVersion, "devel") {
 		adjusted := strings.Replace(message, "unknown unit \"", "unknown unit ", 1)
 		adjusted = strings.Replace(adjusted, "\" in duration \"", " in duration ", 1)
 		adjusted = strings.Replace(adjusted, "\" accessing", " accessing", 1)

--- a/error_test.go
+++ b/error_test.go
@@ -230,6 +230,7 @@ func TestErrorMessages(t *testing.T) {
 // quotas and makes some test assertions failing.
 func adjustMessageFormat(message string) string {
 	adjusted := strings.Replace(message, "unknown unit \"", "unknown unit ", 1)
-	adjusted = strings.Replace(message, "\" in duration", " in duration", 1)
+	adjusted = strings.Replace(adjusted, "\" in duration \"", " in duration ", 1)
+	adjusted = strings.Replace(adjusted, "\" accessing", " accessing", 1)
 	return adjusted
 }

--- a/error_test.go
+++ b/error_test.go
@@ -221,7 +221,7 @@ func TestErrorMessages(t *testing.T) {
 
 			golden := string(tmp)
 			message = adjustMessageFormat(message)
-			assert.Equal(t, golden, message)
+			assert.Equal(t, golden, message, "Go runtime version: %s", runtime.Version())
 		})
 	}
 }

--- a/reify.go
+++ b/reify.go
@@ -155,6 +155,7 @@ func (c *Config) Unpack(to interface{}, options ...Option) error {
 	return reifyInto(opts, vTo, c)
 }
 
+// UnpackWithoutOptions method calls the Unpack method without any options provided.
 func (c *Config) UnpackWithoutOptions(to interface{}) error {
 	return c.Unpack(to)
 }

--- a/reify.go
+++ b/reify.go
@@ -226,7 +226,9 @@ func reifyMap(opts *options, to reflect.Value, from *Config, validators []valida
 		if err != nil {
 			return err
 		}
-		to.SetMapIndex(key, v)
+		if v.IsValid() {
+			to.SetMapIndex(key, v)
+		}
 	}
 
 	if err := runValidators(to.Interface(), validators); err != nil {

--- a/reify.go
+++ b/reify.go
@@ -147,12 +147,16 @@ func (c *Config) Unpack(to interface{}, options ...Option) error {
 	vTo := reflect.ValueOf(to)
 
 	k := vTo.Kind()
-	isValid := to != nil && (k == reflect.Ptr || k == reflect.Map)
+	isValid := k == reflect.Ptr || k == reflect.Map
 	if !isValid {
 		return raisePointerRequired(vTo)
 	}
 
 	return reifyInto(opts, vTo, c)
+}
+
+func (c *Config) UnpackWithoutOptions(to interface{}) error {
+	return c.Unpack(to)
 }
 
 func reifyInto(opts *options, to reflect.Value, from *Config) Error {

--- a/reify.go
+++ b/reify.go
@@ -594,7 +594,9 @@ func reifyDoArray(
 			if err != nil {
 				return reflect.Value{}, err
 			}
-			to.Index(idx).Set(v)
+			if v.IsValid() {
+				to.Index(idx).Set(v)
+			}
 		} else {
 			if err := tryRecursiveValidate(to.Index(idx), opts.opts, nil); err != nil {
 				return reflect.Value{}, raiseValidation(val.Context(), val.meta(), "", err)

--- a/reify.go
+++ b/reify.go
@@ -343,7 +343,9 @@ func reifyGetField(
 		return err
 	}
 
-	to.Set(pointerize(to.Type(), v.Type(), v))
+	if v.IsValid() {
+		to.Set(pointerize(to.Type(), v.Type(), v))
+	}
 	return nil
 }
 

--- a/testdata/error/message/invalid_duration_w_meta.golden
+++ b/testdata/error/message/invalid_duration_w_meta.golden
@@ -1,1 +1,1 @@
-time: unknown unit  hour in duration 1 hour accessing 'timeout' (source:'test.source')
+time-err accessing 'timeout' (source:'test.source')

--- a/testdata/error/message/invalid_duration_wo_meta.golden
+++ b/testdata/error/message/invalid_duration_wo_meta.golden
@@ -1,1 +1,1 @@
-time: unknown unit  hour in duration 1 hour accessing 'timeout'
+time-err accessing 'timeout'

--- a/testdata/error/message/invalid_regexp_w_meta.golden
+++ b/testdata/error/message/invalid_regexp_w_meta.golden
@@ -1,1 +1,1 @@
-Failed to compile regular expression with 'error parsing regexp: missing closing ]: `[`' accessing 'regex' (source:'test.source')
+Failed to compile regular expression with 'regexp-err' accessing 'regex' (source:'test.source')

--- a/testdata/error/message/invalid_regexp_wo_meta.golden
+++ b/testdata/error/message/invalid_regexp_wo_meta.golden
@@ -1,1 +1,1 @@
-Failed to compile regular expression with 'error parsing regexp: missing closing ]: `[`' accessing 'regex'
+Failed to compile regular expression with 'regexp-err' accessing 'regex'

--- a/validator_test.go
+++ b/validator_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
+	"github.com/elastic/go-ucfg/cfgtest"
 )
 
 type myNonzeroInt int
@@ -63,18 +63,6 @@ type nestedNestedPtrStructValidator struct {
 var errZeroTest = errors.New("value must not be 0")
 var errEmptyTest = errors.New("value must not be empty")
 var errMoreTest = errors.New("value must have more than 1 element")
-
-func mustFailUnpack(t *testing.T, cfg *Config, test interface{}) {
-	if err := cfg.Unpack(test); err == nil {
-		t.Fatalf("config:%s test:%s error:%v", spew.Sdump(cfg), spew.Sdump(test), err)
-	}
-}
-
-func mustUnpack(t *testing.T, cfg *Config, test interface{}) {
-	if err := cfg.Unpack(test); err != nil {
-		t.Fatalf("config:%s test:%s error:%v", spew.Sdump(cfg), spew.Sdump(test), err)
-	}
-}
 
 func (m myNonzeroInt) Validate() error {
 	return testZeroErr(int(m))
@@ -321,7 +309,7 @@ func TestValidationPass(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("Test config (%v): %#v", i, test), func(t *testing.T) {
-			mustUnpack(t, c, test)
+			cfgtest.MustUnpack(t, c, test)
 		})
 	}
 }
@@ -545,7 +533,7 @@ func TestValidationFail(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("Test config (%v): %#v", i, test), func(t *testing.T) {
-			mustFailUnpack(t, c, test)
+			cfgtest.MustFailUnpack(t, c, test)
 		})
 	}
 }
@@ -986,7 +974,7 @@ func TestValidationFailOnDefaults(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("Test config (%v): %#v", i, test), func(t *testing.T) {
-			mustFailUnpack(t, c, test)
+			cfgtest.MustFailUnpack(t, c, test)
 		})
 	}
 }

--- a/yaml/yaml_test.go
+++ b/yaml/yaml_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/go-ucfg"
+	"github.com/elastic/go-ucfg/cfgtest"
 )
 
 func TestPrimitives(t *testing.T) {
@@ -220,7 +221,7 @@ func TestEmptyCollections(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			c := mustNewConfig(t, test.input)
-			mustUnpack(t, c, test.to)
+			cfgtest.MustUnpack(t, c, test.to)
 			assert.Equal(t, test.want, test.to)
 		})
 	}
@@ -232,11 +233,4 @@ func mustNewConfig(t *testing.T, input string) *ucfg.Config {
 		t.Fatalf("failed to parse input: %v", err)
 	}
 	return c
-}
-
-func mustUnpack(t *testing.T, c *ucfg.Config, to interface{}) {
-	err := c.Unpack(to)
-	if err != nil {
-		t.Fatalf("unpacking configuration failed: %v", err)
-	}
 }

--- a/yaml/yaml_test.go
+++ b/yaml/yaml_test.go
@@ -131,3 +131,101 @@ a: []
 	assert.Nil(t, err)
 	assert.Nil(t, verify.A)
 }
+
+func TestEmptyArrayInStructIntoArrayOfInterfaces(t *testing.T) {
+	input := []byte(`
+a: []
+`)
+
+	c, err := NewConfig(input)
+	if err != nil {
+		t.Fatalf("failed to parse input: %v", err)
+	}
+
+	verify := struct {
+		A []interface{}
+	}{}
+	err = c.Unpack(&verify)
+	assert.Nil(t, err)
+	assert.Equal(t, []interface{}{}, verify.A)
+}
+
+func TestEmptyArrayIntoArrayOfInterfaces(t *testing.T) {
+	input := []byte(`[]`)
+
+	c, err := NewConfig(input)
+	if err != nil {
+		t.Fatalf("failed to parse input: %v", err)
+	}
+
+	var verify []interface{}
+	err = c.Unpack(&verify)
+	assert.Nil(t, err)
+	assert.Equal(t, []interface{}{}, verify)
+}
+
+func TestEmptyMapIntoInterface(t *testing.T) {
+	input := []byte(`{}`)
+
+	c, err := NewConfig(input)
+	if err != nil {
+		t.Fatalf("failed to parse input: %v", err)
+	}
+
+	verify := struct {
+		A interface{}
+	}{}
+	err = c.Unpack(&verify)
+	assert.Nil(t, err)
+	assert.Nil(t, verify.A)
+}
+
+func TestEmptyMapInStructIntoInterface(t *testing.T) {
+	input := []byte(`
+a: {}
+`)
+
+	c, err := NewConfig(input)
+	if err != nil {
+		t.Fatalf("failed to parse input: %v", err)
+	}
+
+	verify := struct {
+		A interface{}
+	}{}
+	err = c.Unpack(&verify)
+	assert.Nil(t, err)
+	assert.Nil(t, verify.A)
+}
+
+func TestEmptyMapInStructIntoMapOfInterfaces(t *testing.T) {
+	input := []byte(`
+a: {}
+`)
+
+	c, err := NewConfig(input)
+	if err != nil {
+		t.Fatalf("failed to parse input: %v", err)
+	}
+
+	verify := struct {
+		A map[string]interface{}
+	}{}
+	err = c.Unpack(&verify)
+	assert.Nil(t, err)
+	assert.Equal(t, map[string]interface{}{}, verify.A)
+}
+
+func TestEmptyMapIntoMapOfInterfaces(t *testing.T) {
+	input := []byte(`{}`)
+
+	c, err := NewConfig(input)
+	if err != nil {
+		t.Fatalf("failed to parse input: %v", err)
+	}
+
+	var verify map[string]interface{}
+	err = c.Unpack(&verify)
+	assert.Nil(t, err)
+	assert.Equal(t, map[string]interface{}{}, verify)
+}

--- a/yaml/yaml_test.go
+++ b/yaml/yaml_test.go
@@ -114,24 +114,9 @@ func TestArray(t *testing.T) {
 	assert.Equal(t, verify[1]["c"], 4)
 }
 
-type hasVars struct {
-	Vars []variable
-}
-
-type variable struct {
-	Default interface{}
-}
-
-func TestStructEmptyArray(t *testing.T) {
+func TestEmptyArrayIntoInterface(t *testing.T) {
 	input := []byte(`
-vars:
-  - default: []
-  - default: null
-  - default: 3
-  - default:
-    - a
-    - b
-    - c
+a: []
 `)
 
 	c, err := NewConfig(input)
@@ -139,12 +124,10 @@ vars:
 		t.Fatalf("failed to parse input: %v", err)
 	}
 
-	var verify hasVars
+	verify := struct {
+		A interface{}
+	}{}
 	err = c.Unpack(&verify)
 	assert.Nil(t, err)
-
-	assert.Nil(t, verify.Vars[0].Default)
-	assert.Nil(t, verify.Vars[1].Default)
-	assert.Equal(t, uint64(3), verify.Vars[2].Default)
-	assert.Len(t, verify.Vars[3].Default.([]interface{}), 3)
+	assert.Nil(t, verify.A)
 }

--- a/yaml/yaml_test.go
+++ b/yaml/yaml_test.go
@@ -113,3 +113,38 @@ func TestArray(t *testing.T) {
 	assert.Equal(t, verify[0]["c"], 3)
 	assert.Equal(t, verify[1]["c"], 4)
 }
+
+type hasVars struct {
+	Vars []variable
+}
+
+type variable struct {
+	Default interface{}
+}
+
+func TestStructEmptyArray(t *testing.T) {
+	input := []byte(`
+vars:
+  - default: []
+  - default: null
+  - default: 3
+  - default:
+    - a
+    - b
+    - c
+`)
+
+	c, err := NewConfig(input)
+	if err != nil {
+		t.Fatalf("failed to parse input: %v", err)
+	}
+
+	var verify hasVars
+	err = c.Unpack(&verify)
+	assert.Nil(t, err)
+
+	assert.Nil(t, verify.Vars[0].Default)
+	assert.Nil(t, verify.Vars[1].Default)
+	assert.Equal(t, uint64(3), verify.Vars[2].Default)
+	assert.Len(t, verify.Vars[3].Default.([]interface{}), 3)
+}

--- a/yaml/yaml_test.go
+++ b/yaml/yaml_test.go
@@ -181,6 +181,7 @@ func TestEmptyCollections(t *testing.T) {
 				"b": 3,
 			},
 			want: &map[string]interface{}{
+				"a": nil,
 				"b": 3,
 			},
 		},


### PR DESCRIPTION
This PR fixes the issue reported in https://github.com/elastic/go-ucfg/issues/159 .

Check if the target is valid, before setting the value. The target field will stay `nil`.

/cc @ruflin 