### PR TITLE
Fix min/max validator error messages

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -287,7 +287,7 @@ func validateMin(v interface{}, param string) error {
 		}
 
 		if min > d {
-			return fmt.Errorf("requires duration < %v", param)
+			return fmt.Errorf("requires duration >= %v", param)
 		}
 		return nil
 	}
@@ -322,7 +322,7 @@ func validateMin(v interface{}, param string) error {
 		return nil
 	}
 
-	return fmt.Errorf("requires value < %v", param)
+	return fmt.Errorf("requires value >= %v", param)
 }
 
 func validateMax(v interface{}, param string) error {
@@ -337,7 +337,7 @@ func validateMax(v interface{}, param string) error {
 		}
 
 		if max < d {
-			return fmt.Errorf("requires duration > %v", param)
+			return fmt.Errorf("requires duration <= %v", param)
 		}
 		return nil
 	}
@@ -372,7 +372,7 @@ func validateMax(v interface{}, param string) error {
 		return nil
 	}
 
-	return fmt.Errorf("requires value > %v", param)
+	return fmt.Errorf("requires value <= %v", param)
 }
 
 // validateRequired implements the `required` validation tag.


### PR DESCRIPTION
It seems the error messages for min/max validators are backwards. Say I have a field with `validate:"min=1, max=5"`.

Supplying a value of 0, I get the error message:

```
Error processing configuration: requires value < 1 accessing 'field.name'
```

I would expect that to say `...value >= 1...`

Supplying a value of 6, I get the error message:

```
Error processing configuration: requires value > 5 accessing 'field.name'
```

I would expect that to say `...value <= 5...`