### PR TITLE
Refactor tests in json package to make use of require.NoError to stop test execution when a test fails

### DIFF
--- a/json/json_test.go
+++ b/json/json_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/go-ucfg"
 )
@@ -36,9 +37,7 @@ func TestPrimitives(t *testing.T) {
   }`)
 
 	c, err := NewConfig(input)
-	if err != nil {
-		t.Fatalf("failed to parse input: %v", err)
-	}
+	require.NoError(t, err, "failed to parse input")
 
 	verify := struct {
 		B bool
@@ -48,9 +47,9 @@ func TestPrimitives(t *testing.T) {
 		S string
 	}{}
 	err = c.Unpack(&verify)
-	assert.Nil(t, err)
+	require.NoError(t, err, "failed to unpack config")
 
-	assert.Equal(t, true, verify.B)
+	assert.True(t, verify.B)
 	assert.Equal(t, 42, verify.I)
 	assert.Equal(t, uint(23), verify.U)
 	assert.Equal(t, 3.14, verify.F)
@@ -66,15 +65,13 @@ func TestNested(t *testing.T) {
   }`)
 
 	c, err := NewConfig(input)
-	if err != nil {
-		t.Fatalf("failed to parse input: %v", err)
-	}
+	require.NoError(t, err, "failed to parse input")
 
 	var verify struct {
 		C struct{ B bool }
 	}
 	err = c.Unpack(&verify)
-	assert.NoError(t, err)
+	require.NoError(t, err, "failed to unpack config")
 	assert.True(t, verify.C.B)
 }
 
@@ -85,15 +82,13 @@ func TestNestedPath(t *testing.T) {
   }`)
 
 	c, err := NewConfig(input, ucfg.PathSep("."))
-	if err != nil {
-		t.Fatalf("failed to parse input: %v", err)
-	}
+	require.NoError(t, err, "failed to parse input")
 
 	var verify struct {
 		C struct{ B bool }
 	}
 	err = c.Unpack(&verify)
-	assert.NoError(t, err)
+	require.NoError(t, err, "failed to unpack config")
 	assert.True(t, verify.C.B)
 }
 
@@ -111,13 +106,12 @@ func TestArray(t *testing.T) {
 `)
 
 	c, err := NewConfig(input)
-	if err != nil {
-		t.Fatalf("failed to parse input: %v", err)
-	}
+	require.NoError(t, err, "failed to parse input")
 
-	verify := []map[string]int{}
+	var verify []map[string]int
 	err = c.Unpack(&verify)
-	assert.Nil(t, err)
+	require.NoError(t, err, "failed to unpack config")
+	require.Len(t, verify, 2)
 
 	assert.Equal(t, verify[0]["b"], 2)
 	assert.Equal(t, verify[0]["c"], 3)


### PR DESCRIPTION
Explicit error check can be easily replaced with `require.NoError` which does exactly the same thing, i.e. the package require implements the same assertions as the assert package but stops test execution when a test fails:- When constructing a new configuration object from the JSON bytes that is passed in as input, it makes more sense to check the error by using `require.NoError`; we can stop test execution right way when the assertion fails. This is applicable while performing an unpack. Aside from that, it is always safer to check the length of options unpacked into the slice right before accessing the elements based on index to avoid panic. Also replaced empty slice declaration via literal from TestArray with nil slice.