### PR TITLE
Provide mustNewConfig and mustUnpack for Hjson config tests to promote reusability

### DIFF
--- a/hjson/hjson_test.go
+++ b/hjson/hjson_test.go
@@ -27,17 +27,14 @@ import (
 )
 
 func TestPrimitives(t *testing.T) {
-	input := []byte(`
+	input := `
 b: true
 i: 42
 u: 23
 f: 3.14
 s: string
-`)
-
-	c, err := NewConfig(input)
-	require.NoError(t, err, "failed to parse input")
-
+`
+	c := mustNewConfig(t, input)
 	verify := struct {
 		B bool
 		I int
@@ -45,8 +42,7 @@ s: string
 		F float64
 		S string
 	}{}
-	err = c.Unpack(&verify)
-	require.NoError(t, err, "failed to unpack config")
+	mustUnpack(t, c, &verify)
 
 	assert.Equal(t, true, verify.B)
 	assert.Equal(t, 42, verify.I)
@@ -56,41 +52,33 @@ s: string
 }
 
 func TestNested(t *testing.T) {
-	input := []byte(`
+	input := `
 c: {
 	b: true
 }
-`)
-
-	c, err := NewConfig(input)
-	require.NoError(t, err, "failed to parse input")
-
+`
+	c := mustNewConfig(t, input)
 	var verify struct {
 		C struct{ B bool }
 	}
-	err = c.Unpack(&verify)
-	require.NoError(t, err, "failed to unpack config")
+	mustUnpack(t, c, &verify)
 	assert.True(t, verify.C.B)
 }
 
 func TestNestedPath(t *testing.T) {
-	input := []byte(`
+	input := `
 c.b: true
-`)
-
-	c, err := NewConfig(input, ucfg.PathSep("."))
-	require.NoError(t, err, "failed to parse input")
-
+`
+	c := mustNewConfig(t, input, ucfg.PathSep("."))
 	var verify struct {
 		C struct{ B bool }
 	}
-	err = c.Unpack(&verify)
-	require.NoError(t, err, "failed to unpack config")
+	mustUnpack(t, c, &verify)
 	assert.True(t, verify.C.B)
 }
 
 func TestArray(t *testing.T) {
-	input := []byte(`
+	input := `
 [
 	{
 		b: 2
@@ -100,17 +88,28 @@ func TestArray(t *testing.T) {
 		c: 4
 	}
 ]
-`)
-
-	c, err := NewConfig(input)
-	require.NoError(t, err, "failed to parse input")
-
+`
+	c := mustNewConfig(t, input)
 	var verify []map[string]int
-	err = c.Unpack(&verify)
-	require.NoError(t, err, "failed to unpack config")
+	mustUnpack(t, c, &verify)
 	require.Len(t, verify, 2)
 
 	assert.Equal(t, verify[0]["b"], 2)
 	assert.Equal(t, verify[0]["c"], 3)
 	assert.Equal(t, verify[1]["c"], 4)
+}
+
+// mustNewConfig asserts that a new configuration object creation from the given Hjson
+// string with or without options was successful and returned no error (i.e. `nil`).
+func mustNewConfig(t *testing.T, input string, opts ...ucfg.Option) *ucfg.Config {
+	c, err := NewConfig([]byte(input), opts...)
+	require.NoError(t, err, "failed to parse input")
+	return c
+}
+
+// mustUnpack asserts that unpacking the given configuration into
+// the target type was successful and returned no error (i.e. `nil`).
+func mustUnpack(t *testing.T, c *ucfg.Config, v interface{}) {
+	err := c.Unpack(v)
+	require.NoError(t, err, "failed to unpack config")
 }


### PR DESCRIPTION
Provided mustNewConfig and mustUnpack for Hjson config tests to promote reusability