### PR TITLE
Preserve empty untyped arrays when reifying

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
         withGithubNotify(context: 'Check') {
           deleteDir()
           unstash 'source'
-          withGoEnv(version: '1.14', pkgs: ['github.com/elastic/go-licenser', 'go.elastic.co/go-licence-detector']){
+          withGoEnv(version: '1.17', pkgs: ['github.com/elastic/go-licenser', 'go.elastic.co/go-licence-detector']){
             dir("${BASE_DIR}"){
               sh(label: '.ci/check.sh', script: '.ci/check.sh')
             }
@@ -53,7 +53,7 @@ pipeline {
         axes {
           axis {
             name 'GO_VERSION'
-            values '1.13', '1.14', '1.15'
+            values '1.13', '1.14', '1.15', '1.16', '1.17'
           }
         }
         stages {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
         axes {
           axis {
             name 'GO_VERSION'
-            values '1.13', '1.14', '1.15', '1.16', '1.17'
+            values '1.16', '1.17'
           }
         }
         stages {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fixed panic on zero Value while processing a collection of interfaces. #159
+- Preserve empty arrays when reifying #188
 
 ## [0.8.3]
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,4 +1,4 @@
-Copyright 2016-2020 Elasticsearch BV
+Copyright 2016-2021 Elasticsearch BV
 
 This product includes software developed by The Apache Software
 Foundation (http://www.apache.org/).

--- a/types.go
+++ b/types.go
@@ -372,6 +372,9 @@ func (c cfgSub) reify(opts *options) (interface{}, error) {
 	arr := c.c.fields.array()
 
 	switch {
+	case len(fields) == 0 && len(arr) == 0 && arr != nil:
+		// preserve empty arrays
+		return []interface{}{}, nil
 	case len(fields) == 0 && len(arr) == 0:
 		return nil, nil
 	case len(fields) > 0 && len(arr) == 0:

--- a/yaml/yaml_test.go
+++ b/yaml/yaml_test.go
@@ -115,12 +115,12 @@ func TestEmptyCollections(t *testing.T) {
 			to:    &[]interface{}{},
 			want:  &[]interface{}{},
 		},
-		"empty array into array of string" : {
+		"empty array into array of string": {
 			input: `a: []`,
 			to: &struct {
 				A []string
 			}{},
-			want: &struct{A []string}{A:[]string{}},
+			want: &struct{ A []string }{A: []string{}},
 		},
 		"struct with empty map into struct with interface": {
 			input: "a: {}",
@@ -157,7 +157,7 @@ func TestEmptyCollections(t *testing.T) {
 		"struct with empty array into map of interfaces": {
 			input: `{"a": []}`,
 			to:    &map[string]interface{}{},
-			want:  &map[string]interface{}{
+			want: &map[string]interface{}{
 				"a": []interface{}{},
 			},
 		},

--- a/yaml/yaml_test.go
+++ b/yaml/yaml_test.go
@@ -115,6 +115,13 @@ func TestEmptyCollections(t *testing.T) {
 			to:    &[]interface{}{},
 			want:  &[]interface{}{},
 		},
+		"empty array into array of string" : {
+			input: `a: []`,
+			to: &struct {
+				A []string
+			}{},
+			want: &struct{A []string}{A:[]string{}},
+		},
 		"struct with empty map into struct with interface": {
 			input: "a: {}",
 			to: &struct {
@@ -150,7 +157,9 @@ func TestEmptyCollections(t *testing.T) {
 		"struct with empty array into map of interfaces": {
 			input: `{"a": []}`,
 			to:    &map[string]interface{}{},
-			want:  &map[string]interface{}{},
+			want:  &map[string]interface{}{
+				"a": []interface{}{},
+			},
 		},
 		"struct with empty array into map of interfaces with existing fields": {
 			input: `{"a": []}`,
@@ -159,7 +168,7 @@ func TestEmptyCollections(t *testing.T) {
 				"b": 3,
 			},
 			want: &map[string]interface{}{
-				"a": nil,
+				"a": []interface{}{},
 				"b": 3,
 			},
 		},
@@ -185,7 +194,7 @@ func TestEmptyCollections(t *testing.T) {
 			input: `[[]]`,
 			to:    &[]interface{}{},
 			want: &[]interface{}{
-				nil,
+				[]interface{}{},
 			},
 		},
 		"empty array in array into array of array of interfaces": {


### PR DESCRIPTION
Fixes #188 

This adds a special case for empty arrays when reifying configuration objects during Unpack. This is a breaking change compared to existing behaviour as visible in the test cases I adjusted. The original issue #160 that introduced said tests is however still addressed.