### PR TITLE
Add flag to ignore commas when parsing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,22 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
-- Added new parse.Config flag to disable using commas to imply arrays. #192
 
 ### Changed
-- The parse.NoopConfig disables using commas to imply arrays by default. #192
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+## [0.8.5]
+
+### Added
+- Added new parse.Config flag to disable using commas to imply arrays. #192
+
+### Changed
+- The parse.NoopConfig disables using commas to imply arrays by default. #192
 
 ## [0.8.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Added new parse.Config flag to disable using commas to imply arrays. #192
 
 ### Changed
+- The parse.NoopConfig disables using commas to imply arrays by default. #192
 
 ### Deprecated
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,4 +1,4 @@
-Copyright 2016-2021 Elasticsearch BV
+Copyright 2016-2022 Elasticsearch BV
 
 This product includes software developed by The Apache Software
 Foundation (http://www.apache.org/).

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -722,60 +722,36 @@ func TestFlagValueParsingWithNoop(t *testing.T) {
 		{`[]`, `[]`},
 		{
 			`a,b,c`,
-			[]interface{}{"a", "b", "c"},
+			`a,b,c`,
 		},
 		{
 			`C:\Windows\Path1,C:\Windows\Path2`,
-			[]interface{}{
-				`C:\Windows\Path1`,
-				`C:\Windows\Path2`,
-			},
+			`C:\Windows\Path1,C:\Windows\Path2`,
 		},
 		{
 			`[array, 1, true, "abc"]`,
-			[]interface{}{"[array", uint64(1), true, `"abc"]`},
+			`[array, 1, true, "abc"]`,
 		},
 		{
 			`[test, [1,2,3], on]`,
-			[]interface{}{
-				"[test",
-				"[1",
-				uint64(2),
-				"3]",
-				"on]",
-			},
+			`[test, [1,2,3], on]`,
 		},
 		{
 			`[host1:1234, host2:1234]`,
-			[]interface{}{
-				"[host1:1234",
-				"host2:1234]",
-			},
+			`[host1:1234, host2:1234]`,
 		},
 
 		// test dictionaries:
 		{`{}`, `{}`},
-		{`{'key1': true,
-       "key2": 1,
-       key 3: ['test', "test2", off],
-	   nested key: {"a" : 2}}`,
-			[]interface{}{
-				`{'key1': true`,
-				`"key2": 1`,
-				`key 3: ['test'`,
-				`"test2"`,
-				`off]`,
-				`nested key: {"a" : 2}}`,
-			},
+		{
+			`{'key1': true, "key2": 1, key 3: ['test', "test2", off], nested key: {"a" : 2}}`,
+			`{'key1': true, "key2": 1, key 3: ['test', "test2", off], nested key: {"a" : 2}}`,
 		},
 
 		// array of top-level dictionaries
 		{
 			`{key: 1},{key: 2}`,
-			[]interface{}{
-				"{key: 1}",
-				"{key: 2}",
-			},
+			`{key: 1},{key: 2}`,
 		},
 	}
 


### PR DESCRIPTION
The new flag stops the parser from building arrays automatically when
top level elements are separated with commas. This flag converts parsing
into an actual no-op, passing through the input unmodified. This mode is
necessary when parsing values that may legitimately contain special
characters, like secrets.

This is the first step in fixing https://github.com/elastic/beats/issues/29789. A follow up change in beats will follow to start ignoring commas when loading from the keystore.

Draft beats PR with a failing test that will pass with these changes: https://github.com/elastic/beats/pull/31487