### PR TITLE
Add exported IgnoreCommas option to fix parser issues

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,4 +1,4 @@
-Copyright 2016-2023 Elasticsearch BV
+Copyright 2016-2024 Elasticsearch BV
 
 This product includes software developed by The Apache Software
 Foundation (http://www.apache.org/).

--- a/opts.go
+++ b/opts.go
@@ -47,6 +47,8 @@ type options struct {
 	parsed valueCache
 
 	activeFields *fieldSet
+
+	ignoreCommas bool
 }
 
 type valueCache map[string]spliceValue
@@ -73,6 +75,12 @@ func StructTag(tag string) Option {
 	return func(o *options) {
 		o.tag = tag
 	}
+}
+
+var IgnoreCommas = doIgnoreCommas
+
+func doIgnoreCommas(o *options) {
+	o.ignoreCommas = true
 }
 
 // ValidatorTag option sets the struct tag name used to set validators

--- a/types.go
+++ b/types.go
@@ -561,7 +561,11 @@ func parseValue(p *cfgPrimitive, opts *options, str string, parseCfg parse.Confi
 		return nil, raiseNoParse(p.ctx, p.meta())
 	}
 
-	parseCfg.IgnoreCommas = opts.ignoreCommas
+	// only set IgnoreCommas if the default has been changed.
+	if opts.ignoreCommas {
+		parseCfg.IgnoreCommas = opts.ignoreCommas
+	}
+
 	ifc, err := parse.ValueWithConfig(str, parseCfg)
 	if err != nil {
 		return nil, err

--- a/types.go
+++ b/types.go
@@ -561,6 +561,7 @@ func parseValue(p *cfgPrimitive, opts *options, str string, parseCfg parse.Confi
 		return nil, raiseNoParse(p.ctx, p.meta())
 	}
 
+	parseCfg.IgnoreCommas = opts.ignoreCommas
 	ifc, err := parse.ValueWithConfig(str, parseCfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes https://github.com/elastic/go-ucfg/issues/196


This is a rather cautious fix for the above issue, as the issue itself (Parsing a config with `VarExp` causes us to also treat any string with a `,` as an array) is so odd that I'm not sure if there are any secret, undocumented use cases that I might break. Therefore this is an opt-in fix, requiring code to send the `IgnoreCommas` option to `Unpack` in order for us to not trigger this bug.

This also includes a number of tests that demonstrate the issue.