### PR TITLE
set IgnoreCommas to Option type

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -84,7 +84,7 @@ func StructTag(tag string) Option {
 	}
 }
 
-var IgnoreCommas = doIgnoreCommas
+var IgnoreCommas Option = doIgnoreCommas
 
 func doIgnoreCommas(o *options) {
 	o.ignoreCommas = true


### PR DESCRIPTION
Followup to #192, `elastic-agent` has a `getOptions()` method that checks any options passed to the underlying ucfg calls. It expects the options to be of type `Option`. Alas, without explicitly setting the type in the declaration, go will read the type as `func(*option)` instead of the `Option` type alas.